### PR TITLE
test : run test on linux mac and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - run: corepack enable


### PR DESCRIPTION
This PR is about https://github.com/unjs/nypm/issues/1

Added strategy matrix in workflows file. It now should run tests on `ubuntu-latest` `macos-latest` `windows-latest`
