### PR TITLE
feat: use execa for cross platform search path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ✅ **Auto-installs and use exactly expected version** of package manager using [nodejs/corepack](https://github.com/nodejs/corepack)
 
-✅ **Zero dependency** and low overhead implementation
+✅ **Minimal** implementation
 
 nypm, detects package manager type and version and converts command into package manager CLI arguments. It then uses corepack to execute package manager's command (and download it if necessary).
 
@@ -61,10 +61,10 @@ Import:
 
 ```js
 // ESM
-import { detectPackageManager, addDependency } from 'nypm'
+import { detectPackageManager, addDependency } from "nypm";
 
 // CommonJS
-const { detectPackageManager, addDependency } = require('nypm')
+const { detectPackageManager, addDependency } = require("nypm");
 ```
 
 ## 💻 Development
@@ -93,14 +93,12 @@ Made with 💛
 Published under [MIT License](./LICENSE).
 
 <!-- Badges -->
+
 [npm-version-src]: https://img.shields.io/npm/v/nypm?style=flat-square
 [npm-version-href]: https://npmjs.com/package/nypm
-
 [npm-downloads-src]: https://img.shields.io/npm/dm/nypm?style=flat-square
 [npm-downloads-href]: https://npmjs.com/package/nypm
-
 [github-actions-src]: https://img.shields.io/github/workflow/status/unjs/nypm/ci/main?style=flat-square
 [github-actions-href]: https://github.com/unjs/nypm/actions?query=workflow%3Aci
-
 [codecov-src]: https://img.shields.io/codecov/c/gh/unjs/nypm/main?style=flat-square
 [codecov-href]: https://codecov.io/gh/unjs/nypm

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "release": "pnpm test && standard-version && git push --follow-tags && pnpm publish",
     "test": "pnpm lint && vitest run --coverage"
   },
+  "dependencies": {
+    "execa": "^7.1.1"
+  },
   "devDependencies": {
     "@types/node": "^18.15.11",
     "@vitest/coverage-c8": "^0.29.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: '6.0'
 
+dependencies:
+  execa:
+    specifier: ^7.1.1
+    version: 7.1.1
+
 devDependencies:
   '@types/node':
     specifier: ^18.15.11
@@ -1280,7 +1285,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -1932,7 +1936,6 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
-    dev: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2095,7 +2098,6 @@ packages:
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-    dev: true
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -2298,7 +2300,6 @@ packages:
   /human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
-    dev: true
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -2490,7 +2491,6 @@ packages:
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -2532,7 +2532,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -2700,7 +2699,6 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2723,7 +2721,6 @@ packages:
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
-    dev: true
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -2861,7 +2858,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0
-    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -2917,7 +2913,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       mimic-fn: 4.0.0
-    dev: true
 
   /open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -3020,12 +3015,10 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -3260,12 +3253,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -3281,7 +3272,6 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3411,7 +3401,6 @@ packages:
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
-    dev: true
 
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -3846,7 +3835,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -11,6 +11,9 @@ export function runCorepack(
   argv: string[],
   options: RunCommandOptions = {}
 ): Promise<boolean> {
+  if (pm === "npm") {
+    return runCommand("npm", argv, options);
+  }
   return runCommand("corepack", [pm, ...argv], options);
 }
 

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -6,21 +6,27 @@ export interface RunCommandOptions {
   silent?: boolean;
 }
 
-export function runCorepack (pm: string, argv: string[], options: RunCommandOptions = {}): Promise<true> {
+export function runCorepack(
+  pm: string,
+  argv: string[],
+  options: RunCommandOptions = {}
+): Promise<boolean> {
   return runCommand("corepack", [pm, ...argv], options);
 }
 
-function runCommand (command: string, argv: string[], options: RunCommandOptions = {}): Promise<true> {
-  const child = spawn(command, argv, {
-    cwd: resolve(options.cwd || process.cwd()),
-    stdio: options.silent ? "ignore" : "inherit"
-  });
-  return new Promise((resolve, reject) => {
-    child.on("exit", (code) => {
-      if (code !== 0) {
-        return reject(new Error(`${command} ${argv.join(" ")} failed (exit code: ${code})`));
-      }
-      return resolve(true);
+async function runCommand(
+  command: string,
+  argv: string[],
+  options: RunCommandOptions = {}
+): Promise<boolean> {
+  const { execa } = await import("execa");
+  try {
+    await execa(command, argv, {
+      cwd: resolve(options.cwd || process.cwd()),
+      stdio: options.silent ? "ignore" : "inherit",
     });
-  });
+  } catch {
+    return false;
+  }
+  return true;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -60,7 +60,7 @@ describe("api", () => {
             silent: false,
           })
         ).toBeTruthy();
-      }, 10_000);
+      }, 30_000);
     });
   }
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -71,7 +71,7 @@ describe("api", () => {
           ).toBeTruthy();
         });
       },
-      { timeout: 10_000 }
+      { timeout: 20_000 }
     );
   }
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,20 +51,27 @@ describe("detectPackageManager", () => {
 
 describe("api", () => {
   for (const fixture of fixtures) {
-    describe(fixture.name, () => {
-      const fixtureDirectory = resolveFixtureDirectory(fixture.name);
-      it("addDependency", async () => {
-        expect(
-          await addDependency("pathe", { cwd: fixtureDirectory, silent: false })
-        ).toBeTruthy();
-        expect(
-          await addDependency("ufo", {
-            cwd: fixtureDirectory,
-            dev: true,
-            silent: false,
-          })
-        ).toBeTruthy();
-      });
-    });
+    describe(
+      fixture.name,
+      () => {
+        const fixtureDirectory = resolveFixtureDirectory(fixture.name);
+        it("addDependency", async () => {
+          expect(
+            await addDependency("pathe", {
+              cwd: fixtureDirectory,
+              silent: false,
+            })
+          ).toBeTruthy();
+          expect(
+            await addDependency("ufo", {
+              cwd: fixtureDirectory,
+              dev: true,
+              silent: false,
+            })
+          ).toBeTruthy();
+        });
+      },
+      { timeout: 10_000 }
+    );
   }
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,27 +51,16 @@ describe("detectPackageManager", () => {
 
 describe("api", () => {
   for (const fixture of fixtures) {
-    describe(
-      fixture.name,
-      () => {
-        const fixtureDirectory = resolveFixtureDirectory(fixture.name);
-        it("addDependency", async () => {
-          expect(
-            await addDependency("pathe", {
-              cwd: fixtureDirectory,
-              silent: false,
-            })
-          ).toBeTruthy();
-          expect(
-            await addDependency("ufo", {
-              cwd: fixtureDirectory,
-              dev: true,
-              silent: false,
-            })
-          ).toBeTruthy();
-        });
-      },
-      { timeout: 20_000 }
-    );
+    describe(fixture.name, () => {
+      const fixtureDirectory = resolveFixtureDirectory(fixture.name);
+      it("addDependency", async () => {
+        expect(
+          await addDependency("pathe", {
+            cwd: fixtureDirectory,
+            silent: false,
+          })
+        ).toBeTruthy();
+      }, 10_000);
+    });
   }
 });


### PR DESCRIPTION
Try using execa for better cross platform support (search path for `corepack`). Later might remove again to reduce footprint