### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import {
   installDependencies,
   addDependency,
   addDevDependency,
-  removeDependendency,
+  removeDependency,
 } from "nypm";
 
 // CommonJS
@@ -75,7 +75,7 @@ const {
   installDependencies,
   addDependency,
   addDevDependency,
-  removeDependendency,
+  removeDependency,
 } = require("nypm");
 ```
 


### PR DESCRIPTION
Thanks for this super helpful project. Got to integrate it with a project and saw "'"nypm"' has no exported member named 'removeDependendency'. Did you mean 'removeDependency'?ts(2724)" 

This PR to fix the typo. 

