### PR TITLE
chore: update link to nyan cat video 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Removes dependency from the project.
 ## 💻 Development
 
 - Clone this repository
-- Play [Nyan Cat](https://www.youtube.com/watch?v=QH2-TGUlwu4) in the background (really important!)
+- Play [Nyan Cat](https://www.youtube.com/watch?v=2yJgwwDcgV8) in the background (really important!)
 - Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable` (use `npm i -g corepack` for Node.js < 16.10)
 - Install dependencies using `pnpm install`
 - Run interactive tests using `pnpm dev`


### PR DESCRIPTION
The original nyan cat video was taken down in 2023 and now the link in the "development" section of your readme leads to a 404 page. This PR replaces the link with a reupload. This is a critical issue, and it must be fixed immediately.

![Nyan Cat gif](https://media1.tenor.com/m/2roX3uxz_68AAAAC/cat-space.gif)