### PR TITLE
fix: correct yarn detection

### DIFF
--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -52,13 +52,13 @@ export const packageManagers: PackageManager[] = [
   {
     name: "yarn",
     command: "yarn",
-    majorVersion: "1.0.0",
+    majorVersion: "1",
     lockFile: "yarn.lock",
   },
   {
     name: "yarn",
     command: "yarn",
-    majorVersion: "3.0.0",
+    majorVersion: "3",
     lockFile: "yarn.lock",
     files: [".yarnrc.yml"],
   },

--- a/test/_shared.ts
+++ b/test/_shared.ts
@@ -8,6 +8,7 @@ export type Fixture = {
   packageManager: PackageManagerName;
   majorVersion?: string;
   workspace: boolean;
+  files?: string[];
 };
 
 export const fixtures = (
@@ -48,11 +49,13 @@ export const fixtures = (
       name: "yarn-berry",
       packageManager: "yarn",
       majorVersion: "3",
+      files: [".yarnrc.yml"],
     },
     {
       name: "yarn-berry-workspace",
       packageManager: "yarn",
       majorVersion: "3",
+      files: [".yarnrc.yml"],
     },
   ] satisfies Partial<Fixture>[]
 )

--- a/test/detect.test.ts
+++ b/test/detect.test.ts
@@ -13,6 +13,9 @@ describe("detectPackageManager", () => {
         if (fixture.majorVersion) {
           expect(detected?.majorVersion).toBe(fixture.majorVersion);
         }
+        if (fixture.files) {
+          expect(detected?.files).toEqual(fixture.files);
+        }
       });
 
       it.skipIf(fixture.name.includes("berry") /* TODO */)(


### PR DESCRIPTION
Hi! 👋 
Thanks for the project, it has been of great help for my own project: https://github.com/LekoArts/secco

I've found a small bug in this codepath:

```ts
const packageManager =
  packageManagers.find(
    (pm) => pm.name === name && pm.majorVersion === majorVersion,
  ) || packageManagers.find((pm) => pm.name === name);
```

The comparison of `pm.majorVersion === majorVersion` will currently be `3.0.0 === 3`, so it'll fall back to the first name found. So if you e.g. run the detection in a yarn berry project you won't get back the `files` array.

In 3b0f0aa14f2d8efa03c1b5f713f31dee29c58fc3 I added the assertion of `files` to the tests, which then were failing. The commit after that fixes it.

I'll leave some inline comments that we could consider for future PRs but I wanted to discuss first.