### PR TITLE
feat: experimental support for deno v2

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - run: corepack enable
       - uses: oven-sh/setup-bun@v2
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - run: corepack enable
       - uses: oven-sh/setup-bun@v2
         if: ${{ matrix.os != 'windows-latest' }}
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -54,7 +54,10 @@ export async function executeCommand(
   options: Pick<OperationOptions, "cwd" | "silent"> = {},
 ): Promise<void> {
   const execaArgs: [string, string[]] =
-    command === "npm" || command === "bun" || !(await hasCorepack())
+    command === "npm" ||
+    command === "bun" ||
+    command === "deno" ||
+    !(await hasCorepack())
       ? [command, args]
       : ["corepack", [command, ...args]];
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,6 +29,7 @@ export async function installDependencies(
       yarn: ["install", "--immutable"],
       bun: ["install", "--frozen-lockfile"],
       pnpm: ["install", "--frozen-lockfile"],
+      deno: ["install", "--frozen"],
     };
 
   const commandArgs = options.frozenLockFile
@@ -60,6 +61,17 @@ export async function addDependency(
   const resolvedOptions = await resolveOperationOptions(options);
 
   const names = Array.isArray(name) ? name : [name];
+
+  if (resolvedOptions.packageManager.name === "deno") {
+    for (let i = 0; i < names.length; i++) {
+      if (!/^.*?:.+$/.test(names[i])) {
+        console.info(
+          `No prefix found for ${names[i]}. Defaulting to "npm:${names[i]}".`,
+        );
+        names[i] = `npm:${names[i]}`;
+      }
+    }
+  }
 
   // TOOD: we might filter for empty values too for more safety
   if (names.length === 0) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,10 +64,7 @@ export async function addDependency(
 
   if (resolvedOptions.packageManager.name === "deno") {
     for (let i = 0; i < names.length; i++) {
-      if (!/^.*?:.+$/.test(names[i])) {
-        console.info(
-          `No prefix found for ${names[i]}. Defaulting to "npm:${names[i]}".`,
-        );
+      if (!/^(npm|jsr|file):.+$/.test(names[i])) {
         names[i] = `npm:${names[i]}`;
       }
     }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -66,8 +66,8 @@ export const packageManagers: PackageManager[] = [
     name: "deno",
     command: "deno",
     majorVersion: "2",
-    files: ["deno.json"],
     lockFile: "deno.lock",
+    files: ["deno.json"],
   },
 ] as const;
 

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -65,7 +65,6 @@ export const packageManagers: PackageManager[] = [
   {
     name: "deno",
     command: "deno",
-    majorVersion: "2",
     lockFile: "deno.lock",
     files: ["deno.json"],
   },

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -62,6 +62,13 @@ export const packageManagers: PackageManager[] = [
     lockFile: "yarn.lock",
     files: [".yarnrc.yml"],
   },
+  {
+    name: "deno",
+    command: "deno",
+    majorVersion: "2",
+    files: ["deno.json"],
+    lockFile: "deno.lock",
+  },
 ] as const;
 
 /**
@@ -78,7 +85,12 @@ export async function detectPackageManager(
   const detected = await findup(
     resolve(cwd || "."),
     async (path) => {
-      // 1. Use `packageManager` field from package.json
+      // 1. Use `packageManager` field from package.json / deno.json
+      const denoJSONPath = join(path, "deno.json");
+      if (existsSync(denoJSONPath)) {
+        return packageManagers.find((pm) => pm.name === "deno");
+      }
+
       if (!options.ignorePackageJSON) {
         const packageJSONPath = join(path, "package.json");
         if (existsSync(packageJSONPath)) {

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -86,11 +86,6 @@ export async function detectPackageManager(
     resolve(cwd || "."),
     async (path) => {
       // 1. Use `packageManager` field from package.json / deno.json
-      const denoJSONPath = join(path, "deno.json");
-      if (existsSync(denoJSONPath)) {
-        return packageManagers.find((pm) => pm.name === "deno");
-      }
-
       if (!options.ignorePackageJSON) {
         const packageJSONPath = join(path, "package.json");
         if (existsSync(packageJSONPath)) {
@@ -113,6 +108,11 @@ export async function detectPackageManager(
               majorVersion,
             };
           }
+        }
+
+        const denoJSONPath = join(path, "deno.json");
+        if (existsSync(denoJSONPath)) {
+          return packageManagers.find((pm) => pm.name === "deno");
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun";
+export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun" | "deno";
 
 export type PackageManager = {
   name: PackageManagerName;

--- a/test/_shared.ts
+++ b/test/_shared.ts
@@ -14,6 +14,14 @@ export type Fixture = {
 export const fixtures = (
   [
     {
+      name: "deno",
+      packageManager: "deno",
+    },
+    {
+      name: "deno-workspace",
+      packageManager: "deno",
+    },
+    {
       name: "bun",
       packageManager: "bun",
     },

--- a/test/fixtures/deno-workspace/deno.json
+++ b/test/fixtures/deno-workspace/deno.json
@@ -1,0 +1,3 @@
+{
+  "imports": { "consola": "npm:consola@3.2.2" }
+}

--- a/test/fixtures/deno-workspace/deno.lock
+++ b/test/fixtures/deno-workspace/deno.lock
@@ -1,0 +1,21 @@
+{
+  "version": "4",
+  "specifiers": {
+    "npm:consola@3.2.2": "3.2.2"
+  },
+  "npm": {
+    "consola@3.2.2": {
+      "integrity": "sha512-r921u0vbF4lQsoIqYvSSER+yZLPQGijOHrYcWoCNVNBZmn/bRR+xT/DgerTze/nLD9TTGzdDa378TVhx7RDOYg=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:consola@3.2.2"
+    ],
+    "packageJson": {
+      "dependencies": [
+        "npm:consola@3.2.2"
+      ]
+    }
+  }
+}

--- a/test/fixtures/deno-workspace/package.json
+++ b/test/fixtures/deno-workspace/package.json
@@ -1,5 +1,7 @@
 {
   "name": "fixture-deno-workspace",
   "private": true,
-  "dependencies": { "consola": "3.2.2" }
+  "dependencies": {
+    "consola": "3.2.2"
+  }
 }

--- a/test/fixtures/deno-workspace/package.json
+++ b/test/fixtures/deno-workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-deno-workspace",
+  "private": true,
+  "dependencies": { "consola": "3.2.2" }
+}

--- a/test/fixtures/deno-workspace/packages/workspace-a/package.json
+++ b/test/fixtures/deno-workspace/packages/workspace-a/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace-a",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/test/fixtures/deno/deno.json
+++ b/test/fixtures/deno/deno.json
@@ -1,0 +1,3 @@
+{
+  "imports": { "consola": "npm:consola@3.2.2" }
+}

--- a/test/fixtures/deno/deno.lock
+++ b/test/fixtures/deno/deno.lock
@@ -1,0 +1,21 @@
+{
+  "version": "4",
+  "specifiers": {
+    "npm:consola@3.2.2": "3.2.2"
+  },
+  "npm": {
+    "consola@3.2.2": {
+      "integrity": "sha512-r921u0vbF4lQsoIqYvSSER+yZLPQGijOHrYcWoCNVNBZmn/bRR+xT/DgerTze/nLD9TTGzdDa378TVhx7RDOYg=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:consola@3.2.2"
+    ],
+    "packageJson": {
+      "dependencies": [
+        "npm:consola@3.2.2"
+      ]
+    }
+  }
+}

--- a/test/fixtures/deno/package.json
+++ b/test/fixtures/deno/package.json
@@ -1,5 +1,7 @@
 {
   "name": "fixture-deno",
   "private": true,
-  "dependencies": { "consola": "3.2.2" }
+  "dependencies": {
+    "consola": "3.2.2"
+  }
 }

--- a/test/fixtures/deno/package.json
+++ b/test/fixtures/deno/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-deno",
+  "private": true,
+  "dependencies": { "consola": "3.2.2" }
+}


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR adds support for `deno`. As Deno supports reading from `package.json` the only real differences are the following:
- add a default `npm:` prefix to dependencies that do not already have one to align with the behavior of other package managers;
- immediately detect `deno` as the package manager if a `deno.json` file is present in the root folder since `deno` is not a valid entry in the `packageManager` property of `package.json` (if no `deno.json` file is present but a `deno.lock` is, nypm is still able to detect it).

resolves #157.
