### PR TITLE
feat: implement runtime package manager detection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,10 @@ import { resolve } from "pathe";
 import { consola } from "consola";
 import { name, version, description } from "../package.json";
 import { addDependency, installDependencies, removeDependency } from "./api";
-import { detectPackageManager, detectRuntimePackageManager } from "./package-manager";
+import {
+  detectPackageManager,
+  detectRuntimePackageManager,
+} from "./package-manager";
 
 const operationArgs = {
   cwd: {
@@ -99,7 +102,7 @@ const detectRunner = defineCommand({
     description: "Detect the current package runner using runtime checks",
   },
   run: () => {
-    const packageManager = detectRuntimePackageManager()
+    const packageManager = detectRuntimePackageManager();
     if (!packageManager) {
       consola.error(`Cannot detect package runner`);
       return process.exit(1);
@@ -107,8 +110,8 @@ const detectRunner = defineCommand({
     consola.log(
       `Detected package runner \`${packageManager.name}@${packageManager.version}\``,
     );
-  }
-})
+  },
+});
 
 const main = defineCommand({
   meta: {
@@ -125,7 +128,7 @@ const main = defineCommand({
     uninstall: remove,
     un: remove,
     detect,
-    'detect-runner': detectRunner
+    "detect-runner": detectRunner,
   },
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { resolve } from "pathe";
 import { consola } from "consola";
 import { name, version, description } from "../package.json";
 import { addDependency, installDependencies, removeDependency } from "./api";
-import { detectPackageManager } from "./package-manager";
+import { detectPackageManager, detectRuntimePackageManager } from "./package-manager";
 
 const operationArgs = {
   cwd: {
@@ -94,6 +94,22 @@ const detect = defineCommand({
   },
 });
 
+const detectRunner = defineCommand({
+  meta: {
+    description: "Detect the current package runner using runtime checks",
+  },
+  run: () => {
+    const packageManager = detectRuntimePackageManager()
+    if (!packageManager) {
+      consola.error(`Cannot detect package runner`);
+      return process.exit(1);
+    }
+    consola.log(
+      `Detected package runner \`${packageManager.name}@${packageManager.version}\``,
+    );
+  }
+})
+
 const main = defineCommand({
   meta: {
     name,
@@ -109,6 +125,7 @@ const main = defineCommand({
     uninstall: remove,
     un: remove,
     detect,
+    'detect-runner': detectRunner
   },
 });
 

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -29,12 +29,12 @@ export type DetectPackageManagerOptions = {
 
   /**
    * Weather to ignore runtime checks to detect package manager or script runner
-  */
+   */
   ignoreRuntime?: boolean;
 
   /**
-  * Whether to ignore argv[1] to detect package manager or script runner, implied if `ignoreRuntimeChecks` is `true`
-  */
+   * Whether to ignore argv[1] to detect package manager or script runner, implied if `ignoreRuntimeChecks` is `true`
+   */
   ignoreArgv?: boolean;
 };
 
@@ -43,27 +43,27 @@ export const packageManagers: PackageManager[] = [
     name: "npm",
     command: "npm",
     lockFile: "package-lock.json",
-    packageRunner: "npx"
+    packageRunner: "npx",
   },
   {
     name: "pnpm",
     command: "pnpm",
     lockFile: "pnpm-lock.yaml",
     files: ["pnpm-workspace.yaml"],
-    packageRunner: "pnpm dlx"
+    packageRunner: "pnpm dlx",
   },
   {
     name: "bun",
     command: "bun",
     lockFile: ["bun.lockb", "bun.lock"],
-    packageRunner: "bunx"
+    packageRunner: "bunx",
   },
   {
     name: "yarn",
     command: "yarn",
     majorVersion: "1",
     lockFile: "yarn.lock",
-    packageRunner: undefined
+    packageRunner: undefined,
   },
   {
     name: "yarn",
@@ -71,7 +71,7 @@ export const packageManagers: PackageManager[] = [
     majorVersion: "3",
     lockFile: "yarn.lock",
     files: [".yarnrc.yml"],
-    packageRunner: "yarn dlx"
+    packageRunner: "yarn dlx",
   },
 ] as const;
 
@@ -139,18 +139,20 @@ export async function detectPackageManager(
   );
 
   if (!detected && !options.ignoreRuntime) {
-    return detectRuntimePackageManager(options)
+    return detectRuntimePackageManager(options);
   }
 
   return detected;
 }
 
-export function detectRuntimePackageManager(options: DetectPackageManagerOptions = {}): PackageManager | undefined {
-  const userAgent = env['npm_config_user_agent']
+export function detectRuntimePackageManager(
+  options: DetectPackageManagerOptions = {},
+): PackageManager | undefined {
+  const userAgent = env["npm_config_user_agent"];
 
-  const engine = userAgent?.split(' ')?.[0] ?? ''
+  const engine = userAgent?.split(" ")?.[0] ?? "";
 
-  const [name, version = '0.0.0'] = engine.split('/')
+  const [name, version = "0.0.0"] = engine.split("/");
 
   if (name) {
     const majorVersion = version.split(".")[0];
@@ -181,5 +183,4 @@ export function detectRuntimePackageManager(options: DetectPackageManagerOptions
       }
     }
   }
-
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun";
 export type PackageManager = {
   name: PackageManagerName;
   command: string;
+  packageRunner?: string;
   version?: string;
   majorVersion?: string;
   lockFile?: string | string[];


### PR DESCRIPTION
This PR adds a `detectRuntimePackageManager` api function to detect the current package manager in runtime using the `npm-config-user-agent` environment variable. It also adds a refactor so that `argv` parsing can be a safe fallback in the event that the environment variable is not set.   

The possible usecases for this API include 
- Allowing scripts that contain a package manager selector to default to and/or suggest the package manage currently in use
- Enabling silent scripts that don't require user input for package installation (for use in CI environments)

I'm currently marking this as a draft because I'd appreciate suggestions on how to implement tests for this new API. 

References
- pnpm/pnpm#4317
- npm/cli#1919
- yarnpkg/yarn#7127