### PR TITLE
fix(addDependency): compare `name` from resolved `package.json`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -111,7 +111,7 @@ export async function addDependency(
       const pkg = await readPackageJSON(pkgName, {
         url: resolvedOptions.cwd,
       }).catch(() => ({}) as Record<string, undefined>);
-      if (!pkg.peerDependencies || name !== pkgName) {
+      if (!pkg.peerDependencies || pkg.name !== pkgName) {
         continue;
       }
       for (const [peerDependency, version] of Object.entries(


### PR DESCRIPTION
`name` could be an array or a module name with version, e.g. `pkg-name@latest`, so it is unlikely to match the `pkgName` test here.

This bug has been present since I added the feature 🤦 