### PR TITLE
feat(types): improve `PackageManager` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type PackageManager = {
   command: string;
   version?: string;
   majorVersion?: string;
-  lockFile?: string | string[];
+  lockFile: string | string[];
   files?: string[];
 };
 


### PR DESCRIPTION
resolves #173 

Make `PackageManager.lockFile` not undefined.
Use `pkg-types` to read the package json file.
Add if check in rare case that "packageManager" field of package.json is actually unrecognised.

This is honestly super low priority and I only made this so I could remove [this `... | undefined`](https://github.com/nuxt/cli/pull/618/files#diff-62362d03dce63ff9a00b810dd420fcd3f3d5011308d6ab506316319a15327dc9R205).
But I still think this PR has merit as it more accurately reflects the source of truth