### PR TITLE
fix: correctly detect `corepack` for fallback

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -41,8 +41,13 @@ const importTinyexec = cached(() => import("tinyexec").then((r) => r.x));
 const hasCorepack = cached(async () => {
   const x = await importTinyexec();
   const result = x("corepack", ["--version"]);
-  await result;
-  return result.exitCode === 0;
+  try {
+    // This throws an error instead of returning a non-zero exit code
+    await result;
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
 });
 
 export async function executeCommand(

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -40,11 +40,9 @@ function cached<T>(fn: () => Promise<T>): () => T | Promise<T> {
 const importTinyexec = cached(() => import("tinyexec").then((r) => r.x));
 const hasCorepack = cached(async () => {
   const x = await importTinyexec();
-  const result = x("corepack", ["--version"]);
   try {
-    // This throws an error instead of returning a non-zero exit code
-    await result;
-    return result.exitCode === 0;
+    const { exitCode } = await x("corepack", ["--version"]);
+    return exitCode === 0;
   } catch {
     return false;
   }


### PR DESCRIPTION
Reproduction steps can be found at https://github.com/unjs/nypm/issues/178#issue-2787961266

resolves #178 
