### PR TITLE
feat: normalize `packageManager` field when parsing

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -2,7 +2,11 @@ import { createRequire } from "node:module";
 import { normalize, resolve } from "pathe";
 import { withTrailingSlash } from "ufo";
 import { x } from "tinyexec";
-import type { OperationOptions, PackageManager } from "./types";
+import type {
+  OperationOptions,
+  PackageManager,
+  PackageManagerName,
+} from "./types";
 import type { DetectPackageManagerOptions } from "./package-manager";
 import { detectPackageManager, packageManagers } from "./package-manager";
 
@@ -160,7 +164,7 @@ export function doesDependencyExist(
 }
 
 export function parsePackageManagerField(packageManager?: string): {
-  name?: string;
+  name?: PackageManagerName;
   version?: string;
   buildMeta?: string;
   warnings?: string[];
@@ -173,12 +177,17 @@ export function parsePackageManagerField(packageManager?: string): {
     name !== "-" &&
     /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
   ) {
-    return { name, version, buildMeta };
+    return { name: name as PackageManagerName, version, buildMeta };
   }
 
   const sanitized = name.replace(/\W+/g, "");
   const warnings = [
     `Abnormal characters found in \`packageManager\` field, sanitizing from \`${name}\` to \`${sanitized}\``,
   ];
-  return { name: sanitized, version, buildMeta, warnings };
+  return {
+    name: sanitized as PackageManagerName,
+    version,
+    buildMeta,
+    warnings,
+  };
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -159,15 +159,18 @@ export function doesDependencyExist(
   }
 }
 
-export function sanitizePackageManagerName(
-  name: string,
-): [any, string | undefined] {
-  const sanitized = name.replace(/^\W+/, "");
-  if (name !== sanitized) {
-    return [
-      sanitized,
-      `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
-    ];
+export function sanitizePackageManagerName(name: string): {
+  name: any;
+  warning: string | undefined;
+} {
+  const sanitized = /\w+$/.exec(name)?.[0];
+
+  if (sanitized && name !== sanitized) {
+    return {
+      name: sanitized,
+      warning: `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
+    };
   }
-  return [name, undefined];
+
+  return { name, warning: undefined };
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -161,17 +161,18 @@ export function doesDependencyExist(
 
 export function sanitizePackageManagerName(name: string): {
   name: any;
-  warnings: string[];
+  warnings?: string[];
 } {
   const sanitized = name.replace(/\W+/, "");
 
+  if (name === sanitized) {
+    return { name };
+  }
+
   return {
     name: sanitized,
-    warnings:
-      name === sanitized
-        ? []
-        : [
-            `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
-          ],
+    warnings: [
+      `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
+    ],
   };
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -161,16 +161,18 @@ export function doesDependencyExist(
 
 export function sanitizePackageManagerName(name: string): {
   name: any;
-  warning: string | undefined;
+  warnings: string[];
 } {
   const sanitized = /\w+$/.exec(name)?.[0];
 
   if (sanitized && name !== sanitized) {
     return {
       name: sanitized,
-      warning: `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
+      warnings: [
+        `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
+      ],
     };
   }
 
-  return { name, warning: undefined };
+  return { name, warnings: [] };
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -158,3 +158,16 @@ export function doesDependencyExist(
     return false;
   }
 }
+
+export function sanitizePackageManagerName(
+  name: string,
+): [any, string | undefined] {
+  const sanitized = name.replace(/^\W+/, "");
+  if (name !== sanitized) {
+    return [
+      sanitized,
+      `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
+    ];
+  }
+  return [name, undefined];
+}

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -159,8 +159,8 @@ export function doesDependencyExist(
   }
 }
 
-export function parsePackageManagerField(packageManager: string): {
-  name: string;
+export function parsePackageManagerField(packageManager?: string): {
+  name?: string;
   version?: string;
   buildMeta?: string;
   warnings?: string[];
@@ -168,14 +168,17 @@ export function parsePackageManagerField(packageManager: string): {
   const [name, _version] = (packageManager || "").split("@");
   const [version, buildMeta] = _version?.split("+") || [];
 
-  const sanitized = name.replace(/\W+/, "");
-
-  let warnings: string[] | undefined;
-  if (name !== sanitized) {
-    warnings = [
-      `Abnormal characters found in \`packageManager\` field, sanitizing from \`${name}\` to \`${sanitized}\``,
-    ];
+  if (
+    name &&
+    name !== "-" &&
+    /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+  ) {
+    return { name, version, buildMeta };
   }
 
-  return { name, version, buildMeta, warnings };
+  const sanitized = name.replace(/\W+/g, "");
+  const warnings = [
+    `Abnormal characters found in \`packageManager\` field, sanitizing from \`${name}\` to \`${sanitized}\``,
+  ];
+  return { name: sanitized, version, buildMeta, warnings };
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -159,20 +159,23 @@ export function doesDependencyExist(
   }
 }
 
-export function sanitizePackageManagerName(name: string): {
-  name: any;
+export function parsePackageManagerField(packageManager: string): {
+  name: string;
+  version?: string;
+  buildMeta?: string;
   warnings?: string[];
 } {
+  const [name, _version] = (packageManager || "").split("@");
+  const [version, buildMeta] = _version?.split("+") || [];
+
   const sanitized = name.replace(/\W+/, "");
 
-  if (name === sanitized) {
-    return { name };
+  let warnings: string[] | undefined;
+  if (name !== sanitized) {
+    warnings = [
+      `Abnormal characters found in \`packageManager\` field, sanitizing from \`${name}\` to \`${sanitized}\``,
+    ];
   }
 
-  return {
-    name: sanitized,
-    warnings: [
-      `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
-    ],
-  };
+  return { name, version, buildMeta, warnings };
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -163,16 +163,15 @@ export function sanitizePackageManagerName(name: string): {
   name: any;
   warnings: string[];
 } {
-  const sanitized = /\w+$/.exec(name)?.[0];
+  const sanitized = name.replace(/\W+/, "");
 
-  if (sanitized && name !== sanitized) {
-    return {
-      name: sanitized,
-      warnings: [
-        `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
-      ],
-    };
-  }
-
-  return { name, warnings: [] };
+  return {
+    name: sanitized,
+    warnings:
+      name === sanitized
+        ? []
+        : [
+            `Abnormal characters found in \`packageManager\` field, sanitizing from \`'${name}'\` to \`'${sanitized}'\``,
+          ],
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,14 +85,27 @@ const detect = defineCommand({
       type: "string",
       description: "Current working directory",
     },
+    warn: {
+      type: "boolean",
+      description: "Log warnings",
+      default: true,
+    },
   },
   run: async ({ args }) => {
     const cwd = resolve(args.cwd || ".");
     const packageManager = await detectPackageManager(cwd);
+
+    if (args.warn && packageManager?.warnings) {
+      for (const warning of packageManager.warnings) {
+        consola.warn(warning);
+      }
+    }
+
     if (!packageManager) {
       consola.error(`Cannot detect package manager in \`${cwd}\``);
       return process.exit(1);
     }
+
     consola.log(
       `Detected package manager in \`${cwd}\`: \`${packageManager.name}@${packageManager.version}\``,
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,17 +85,12 @@ const detect = defineCommand({
       type: "string",
       description: "Current working directory",
     },
-    warn: {
-      type: "boolean",
-      description: "Log warnings",
-      default: true,
-    },
   },
   run: async ({ args }) => {
     const cwd = resolve(args.cwd || ".");
     const packageManager = await detectPackageManager(cwd);
 
-    if (args.warn && packageManager?.warnings) {
+    if (packageManager?.warnings) {
       for (const warning of packageManager.warnings) {
         consola.warn(warning);
       }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -101,6 +101,7 @@ export async function detectPackageManager(
                     pm.name === p.name && pm.majorVersion === majorVersion,
                 ) || packageManagers.find((pm) => pm.name === p.name);
               return {
+                name: p.name as PackageManager["name"],
                 command: p.name,
                 majorVersion,
                 ...p,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -92,8 +92,12 @@ export async function detectPackageManager(
             await readFile(packageJSONPath, "utf8"),
           );
           if (packageJSON?.packageManager) {
-            const { name, version, buildMeta, warnings } =
-              parsePackageManagerField(packageJSON.packageManager);
+            const {
+              name,
+              version = "0.0.0",
+              buildMeta,
+              warnings,
+            } = parsePackageManagerField(packageJSON.packageManager);
             if (name) {
               const majorVersion = version?.split(".")[0];
               const packageManager =
@@ -103,10 +107,10 @@ export async function detectPackageManager(
               return {
                 name,
                 command: name,
-                version: version || "0.0.0",
+                version,
                 majorVersion,
-                buildMeta: buildMeta,
-                warnings: warnings,
+                buildMeta,
+                warnings,
                 ...packageManager,
               };
             }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -103,7 +103,7 @@ export async function detectPackageManager(
               return {
                 name,
                 command: name,
-                version,
+                version: version || "0.0.0",
                 majorVersion,
                 buildMeta: buildMeta,
                 warnings: warnings,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -80,7 +80,7 @@ export const packageManagers: PackageManager[] = [
 export async function detectPackageManager(
   cwd: string,
   options: DetectPackageManagerOptions = {},
-): Promise<PackageManager | undefined> {
+): Promise<(PackageManager & { warnings?: string[] }) | undefined> {
   const detected = await findup(
     resolve(cwd || "."),
     async (path) => {
@@ -107,7 +107,7 @@ export async function detectPackageManager(
               command: name,
               version,
               majorVersion,
-              warnings: [...sanitizationWarnings],
+              warnings: sanitizationWarnings,
             };
           }
         }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -27,13 +27,6 @@ export type DetectPackageManagerOptions = {
   includeParentDirs?: boolean;
 
   /**
-   * Whether to disable package manager sanitization warning
-   *
-   * @default false
-   */
-  disableSanitizationWarning?: boolean;
-
-  /**
    * Weather to ignore argv[1] to detect script
    */
   ignoreArgv?: boolean;

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -101,7 +101,7 @@ export async function detectPackageManager(
                     pm.name === p.name && pm.majorVersion === majorVersion,
                 ) || packageManagers.find((pm) => pm.name === p.name);
               return {
-                name: p.name as PackageManager["name"],
+                name: p.name,
                 command: p.name,
                 majorVersion,
                 ...p,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -94,7 +94,7 @@ export async function detectPackageManager(
           if (packageJSON?.packageManager) {
             const [rawName, version = "0.0.0"] =
               packageJSON.packageManager.split("@");
-            const [name, sanitizationWarning] =
+            const { name, warning: sanitizationWarning } =
               sanitizePackageManagerName(rawName);
             const majorVersion = version.split(".")[0];
             const packageManager =

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -98,8 +98,7 @@ export async function detectPackageManager(
               const packageManager =
                 packageManagers.find(
                   (pm) =>
-                    pm.name === p.name &&
-                    (majorVersion ? pm.majorVersion === majorVersion : true),
+                    pm.name === p.name && pm.majorVersion === majorVersion,
                 ) || packageManagers.find((pm) => pm.name === p.name);
               return {
                 command: p.name,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -92,19 +92,21 @@ export async function detectPackageManager(
             await readFile(packageJSONPath, "utf8"),
           );
           if (packageJSON?.packageManager) {
-            const p = parsePackageManagerField(packageJSON.packageManager);
-            if (p.name) {
-              const majorVersion = p.version?.split(".")[0];
+            const { name, version, buildMeta, warnings } =
+              parsePackageManagerField(packageJSON.packageManager);
+            if (name) {
+              const majorVersion = version?.split(".")[0];
               const packageManager =
                 packageManagers.find(
-                  (pm) =>
-                    pm.name === p.name && pm.majorVersion === majorVersion,
-                ) || packageManagers.find((pm) => pm.name === p.name);
+                  (pm) => pm.name === name && pm.majorVersion === majorVersion,
+                ) || packageManagers.find((pm) => pm.name === name);
               return {
-                name: p.name,
-                command: p.name,
+                name,
+                command: name,
+                version,
                 majorVersion,
-                ...p,
+                buildMeta: buildMeta,
+                warnings: warnings,
                 ...packageManager,
               };
             }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -99,7 +99,7 @@ export async function detectPackageManager(
               warnings,
             } = parsePackageManagerField(packageJSON.packageManager);
             if (name) {
-              const majorVersion = version?.split(".")[0];
+              const majorVersion = version.split(".")[0];
               const packageManager =
                 packageManagers.find(
                   (pm) => pm.name === name && pm.majorVersion === majorVersion,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -94,7 +94,7 @@ export async function detectPackageManager(
           if (packageJSON?.packageManager) {
             const [rawName, version = "0.0.0"] =
               packageJSON.packageManager.split("@");
-            const { name, warning: sanitizationWarning } =
+            const { name, warnings: sanitizationWarnings } =
               sanitizePackageManagerName(rawName);
             const majorVersion = version.split(".")[0];
             const packageManager =
@@ -107,7 +107,7 @@ export async function detectPackageManager(
               command: name,
               version,
               majorVersion,
-              warnings: [sanitizationWarning].filter(Boolean) as string[],
+              warnings: [...sanitizationWarnings],
             };
           }
         }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -92,20 +92,22 @@ export async function detectPackageManager(
             await readFile(packageJSONPath, "utf8"),
           );
           if (packageJSON?.packageManager) {
-            const parsed = parsePackageManagerField(packageJSON.packageManager);
-            const majorVersion = parsed.version?.split(".")[0];
-            const packageManager =
-              packageManagers.find(
-                (pm) =>
-                  pm.name === parsed.name &&
-                  (majorVersion ? pm.majorVersion === majorVersion : true),
-              ) || packageManagers.find((pm) => pm.name === parsed.name);
-            return {
-              command: parsed.name,
-              majorVersion,
-              ...parsed,
-              ...packageManager,
-            };
+            const p = parsePackageManagerField(packageJSON.packageManager);
+            if (p.name) {
+              const majorVersion = p.version?.split(".")[0];
+              const packageManager =
+                packageManagers.find(
+                  (pm) =>
+                    pm.name === p.name &&
+                    (majorVersion ? pm.majorVersion === majorVersion : true),
+                ) || packageManagers.find((pm) => pm.name === p.name);
+              return {
+                command: p.name,
+                majorVersion,
+                ...p,
+                ...packageManager,
+              };
+            }
           }
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type PackageManager = {
   name: PackageManagerName;
   command: string;
   version?: string;
+  buildMeta?: string;
   majorVersion?: string;
   lockFile?: string | string[];
   files?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type PackageManager = {
   majorVersion?: string;
   lockFile?: string | string[];
   files?: string[];
+  warnings?: string[];
 };
 
 export type OperationOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export type PackageManager = {
   majorVersion?: string;
   lockFile?: string | string[];
   files?: string[];
-  warnings?: string[];
 };
 
 export type OperationOptions = {

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -1,11 +1,30 @@
 import { expect, it, describe } from "vitest";
-import { resolveOperationOptions } from "../src/_utils";
+import {
+  sanitizePackageManagerName,
+  resolveOperationOptions,
+} from "../src/_utils";
 
 describe("internal utils", () => {
   describe("resolveOperationOptions", () => {
     it("resolved package manager by name", async () => {
       const r = await resolveOperationOptions({ packageManager: "yarn" });
       expect(r.packageManager.name).toBe("yarn");
+    });
+  });
+
+  describe("parsePackageManagerName", () => {
+    it("preserves valid (unknown) name", () => {
+      const r = sanitizePackageManagerName("unknownName@0.0.0");
+      expect(r[0]).toBe("unknownName@0.0.0");
+      expect(r[1]).toMatchInlineSnapshot(`undefined`);
+    });
+
+    it("sanitize abnormal characters with warning", () => {
+      const r = sanitizePackageManagerName("~^&#-!yarn@0.0.0");
+      expect(r[0]).toBe("yarn@0.0.0");
+      expect(r[1]).toMatchInlineSnapshot(
+        `"Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn@0.0.0'\` to \`'yarn@0.0.0'\`"`,
+      );
     });
   });
 });

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -16,6 +16,7 @@ describe("internal utils", () => {
     const cases = {
       "": [""],
       npm: ["npm"],
+      "unknown-name": ["unknown-name"],
       unknownName: ["unknownName"],
       "npm@1.2.3": ["npm", "1.2.3"],
       "pnpm@9.15.4+sha512.b2dc20e2fc72b3e": [

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -14,15 +14,15 @@ describe("internal utils", () => {
 
   describe("parsePackageManagerName", () => {
     it("preserves valid (unknown) name", () => {
-      const r = sanitizePackageManagerName("unknownName@0.0.0");
-      expect(r[0]).toBe("unknownName@0.0.0");
-      expect(r[1]).toMatchInlineSnapshot(`undefined`);
+      const [name, warning] = sanitizePackageManagerName("unknownName@0.0.0");
+      expect(name).toBe("unknownName@0.0.0");
+      expect(warning).toMatchInlineSnapshot(`undefined`);
     });
 
     it("sanitize abnormal characters with warning", () => {
-      const r = sanitizePackageManagerName("~^&#-!yarn@0.0.0");
-      expect(r[0]).toBe("yarn@0.0.0");
-      expect(r[1]).toMatchInlineSnapshot(
+      const [name, warning] = sanitizePackageManagerName("~^&#-!yarn@0.0.0");
+      expect(name).toBe("yarn@0.0.0");
+      expect(warning).toMatchInlineSnapshot(
         `"Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn@0.0.0'\` to \`'yarn@0.0.0'\`"`,
       );
     });

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest";
 import {
-  sanitizePackageManagerName,
+  parsePackageManagerField,
   resolveOperationOptions,
 } from "../src/_utils";
 
@@ -12,23 +12,30 @@ describe("internal utils", () => {
     });
   });
 
-  describe("parsePackageManagerName", () => {
-    it("valid (unknown) name without warning", () => {
-      const { name, warnings } = sanitizePackageManagerName("unknownName");
-      expect(name).toBe("unknownName");
-      expect(warnings).toMatchInlineSnapshot(`[]`);
-    });
-
-    it("sanitize abnormal characters with warning", () => {
-      const { name, warnings } = sanitizePackageManagerName("~^&#-!yarn");
-      expect(name).toBe("yarn");
-      expect(warnings).toMatchInlineSnapshot(
-        `
-        [
-          "Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn'\` to \`'yarn'\`",
-        ]
-      `,
-      );
-    });
+  describe("parsePackageManagerField", () => {
+    const cases = {
+      "": [""],
+      npm: ["npm"],
+      unknownName: ["unknownName"],
+      "npm@1.2.3": ["npm", "1.2.3"],
+      "pnpm@9.15.4+sha512.b2dc20e2fc72b3e": [
+        "pnpm",
+        "9.15.4",
+        "sha512.b2dc20e2fc72b3e",
+      ],
+    };
+    for (const [input, [name, version, buildMeta]] of Object.entries(cases)) {
+      it(input, () => {
+        const p = parsePackageManagerField(input);
+        expect(p.name).toBe(name);
+        expect(p.version).toBe(version);
+        expect(p.buildMeta).toBe(buildMeta);
+        if (input.split("@")[0] !== name) {
+          expect(p.warnings).toMatchObject([
+            `Abnormal characters found in \`packageManager\` field, sanitizing from \`${input}\` to \`${name}\``,
+          ]);
+        }
+      });
+    }
   });
 });

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -14,16 +14,20 @@ describe("internal utils", () => {
 
   describe("parsePackageManagerName", () => {
     it("valid (unknown) name without warning", () => {
-      const { name, warning } = sanitizePackageManagerName("unknownName");
+      const { name, warnings } = sanitizePackageManagerName("unknownName");
       expect(name).toBe("unknownName");
-      expect(warning).toMatchInlineSnapshot(`undefined`);
+      expect(warnings).toMatchInlineSnapshot(`[]`);
     });
 
     it("sanitize abnormal characters with warning", () => {
-      const { name, warning } = sanitizePackageManagerName("~^&#-!yarn");
+      const { name, warnings } = sanitizePackageManagerName("~^&#-!yarn");
       expect(name).toBe("yarn");
-      expect(warning).toMatchInlineSnapshot(
-        `"Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn'\` to \`'yarn'\`"`,
+      expect(warnings).toMatchInlineSnapshot(
+        `
+        [
+          "Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn'\` to \`'yarn'\`",
+        ]
+      `,
       );
     });
   });

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -15,6 +15,9 @@ describe("internal utils", () => {
   describe("parsePackageManagerField", () => {
     const cases = {
       "": [""],
+      "-": [""],
+      "*": [""],
+      "^npm": ["npm"],
       npm: ["npm"],
       "unknown-name": ["unknown-name"],
       unknownName: ["unknownName"],

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -13,17 +13,17 @@ describe("internal utils", () => {
   });
 
   describe("parsePackageManagerName", () => {
-    it("preserves valid (unknown) name", () => {
-      const [name, warning] = sanitizePackageManagerName("unknownName@0.0.0");
-      expect(name).toBe("unknownName@0.0.0");
+    it("valid (unknown) name without warning", () => {
+      const { name, warning } = sanitizePackageManagerName("unknownName");
+      expect(name).toBe("unknownName");
       expect(warning).toMatchInlineSnapshot(`undefined`);
     });
 
     it("sanitize abnormal characters with warning", () => {
-      const [name, warning] = sanitizePackageManagerName("~^&#-!yarn@0.0.0");
-      expect(name).toBe("yarn@0.0.0");
+      const { name, warning } = sanitizePackageManagerName("~^&#-!yarn");
+      expect(name).toBe("yarn");
       expect(warning).toMatchInlineSnapshot(
-        `"Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn@0.0.0'\` to \`'yarn@0.0.0'\`"`,
+        `"Abnormal characters found in \`packageManager\` field, sanitizing from \`'~^&#-!yarn'\` to \`'yarn'\`"`,
       );
     });
   });


### PR DESCRIPTION
Resolves #176 

This removes the pattern `^\W+` to drop unexpected characters preceding the package manager name (and version), while still allowing unknown name patterns `\w+`. 

If the pattern removal results in a different package name a warning will be returned and logged when used in the CLI detect command, the warning can be disabled by passing the `--warn false`.

### Notes

* The `sanitizePackageManagerName` returns `any` for the sanitized name, this matches the original behavior, but gives a false sense of type safety, perhaps something to look into in a separate PR.
