### PR TITLE
build: update `exports` for typescript compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "exports": {
     ".": {
       "import": {
-				"types": "./dist/index.d.mts",
-				"default": "./dist/index.mjs"
-			},
-			"require": {
-				"types": "./dist/index.d.cts",
-				"default": "./dist/index.cjs"
-			}
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
     }
   },
   "bin": {


### PR DESCRIPTION
Resolves #185.

Turns out the fix for the issue is straightforward because the build is already generating .d.cts and .d.mts type files - the exports weren't pointing to them correctly. That is now fixed.

Tested by running `npx @arethetypeswrong/cli` before and after this change.