### PR TITLE
fix: stackblitz does not supports corepack

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -43,6 +43,9 @@ function cached<T>(fn: () => Promise<T>): () => T | Promise<T> {
 }
 
 const hasCorepack = cached(async () => {
+  if (globalThis.process?.versions?.webcontainer) {
+    return false;
+  }
   try {
     const { exitCode } = await x("corepack", ["--version"]);
     return exitCode === 0;


### PR DESCRIPTION
This is more of a workaround for https://github.com/tinylibs/tinyexec/issues/46 