### PR TITLE
fix: handle resolving `package.json` from pure esm packages

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -28,13 +28,59 @@ export async function findup<T>(
   }
 }
 
-export async function readPackageJSON(cwd: string): Promise<PackageJson | null> {
-  return findup(cwd, (p) => {
-    const pkgPath = join(p, "package.json");
-    if (existsSync(pkgPath)) {
-      return readFile(pkgPath, "utf8").then((data) => JSON.parse(data));
-    }
-  });
+export async function readPackageJSON(
+  cwd: string,
+  options: Pick<DetectPackageManagerOptions, "includeParentDirs"> = {},
+): Promise<PackageJson | null> {
+  return findup(
+    cwd,
+    (p) => {
+      const pkgPath = join(p, "package.json");
+      if (existsSync(pkgPath)) {
+        return readFile(pkgPath, "utf8").then((data) => JSON.parse(data));
+      }
+    },
+    options,
+  );
+}
+
+export async function readInstalledPackageJSON(
+  pkgName: string,
+  cwd: string,
+): Promise<PackageJson | null> {
+  const pkgJSONPath = await findup(
+    cwd,
+    (p) => {
+      const candidate = join(p, "node_modules", pkgName, "package.json");
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    },
+    { includeParentDirs: true },
+  );
+
+  if (!pkgJSONPath) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(await readFile(pkgJSONPath, "utf8")) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+export async function readPackageJSONFromResolver(
+  requireFn: ReturnType<typeof createRequire>,
+  pkgName: string,
+): Promise<PackageJson | null> {
+  let resolved: string;
+  try {
+    resolved = requireFn.resolve(pkgName);
+  } catch {
+    return null;
+  }
+  return readPackageJSON(resolved, { includeParentDirs: true });
 }
 
 function cached<T>(fn: () => Promise<T>): () => T | Promise<T> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,6 +5,8 @@ import {
   getWorkspaceArgs,
   doesDependencyExist,
   readPackageJSON,
+  readInstalledPackageJSON,
+  readPackageJSONFromResolver,
 } from "./_utils.ts";
 import { dlxCommand } from "./cmd.ts";
 import type { OperationOptions, OperationResult, PackageManagerName } from "./types.ts";
@@ -130,8 +132,13 @@ export async function addDependency(
     const _require = createRequire(join(resolvedOptions.cwd, "/_.js"));
     for (const _name of names) {
       const pkgName = _name.match(/^(.[^@]+)/)?.[0];
-      const pkgEntryPath = _require.resolve(pkgName!);
-      const pkg = await readPackageJSON(pkgEntryPath);
+      if (!pkgName) {
+        continue;
+      }
+      let pkg = await readPackageJSONFromResolver(_require, pkgName);
+      if (!pkg) {
+        pkg = await readInstalledPackageJSON(pkgName, resolvedOptions.cwd);
+      }
       if (!pkg?.peerDependencies || pkg?.name !== pkgName) {
         continue;
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -136,7 +136,7 @@ export async function addDependency(
         continue;
       }
       let pkg = await readPackageJSONFromResolver(_require, pkgName);
-      if (!pkg) {
+      if (!pkg || pkg.name !== pkgName) {
         pkg = await readInstalledPackageJSON(pkgName, resolvedOptions.cwd);
       }
       if (!pkg?.peerDependencies || pkg?.name !== pkgName) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -136,10 +136,10 @@ export async function addDependency(
         continue;
       }
       let pkg = await readPackageJSONFromResolver(_require, pkgName);
-      if (!pkg || pkg.name !== pkgName) {
+      if (pkg?.name !== pkgName) {
         pkg = await readInstalledPackageJSON(pkgName, resolvedOptions.cwd);
       }
-      if (!pkg?.peerDependencies || pkg?.name !== pkgName) {
+      if (!pkg?.peerDependencies) {
         continue;
       }
       for (const [peerDependency, version] of Object.entries(pkg.peerDependencies)) {

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -1,7 +1,91 @@
-import { expect, it, describe } from "vitest";
-import { parsePackageManagerField, resolveOperationOptions } from "../src/_utils.ts";
+import { afterAll, beforeAll, expect, it, describe } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parsePackageManagerField,
+  readInstalledPackageJSON,
+  readPackageJSONFromResolver,
+  resolveOperationOptions,
+} from "../src/_utils.ts";
 
 describe("internal utils", () => {
+  describe("readInstalledPackageJSON", () => {
+    let root!: string;
+
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "nypm-test-"));
+      mkdirSync(join(root, "project", "src"), { recursive: true });
+
+      // scoped pure-ESM package whose `exports` only defines an `import`
+      // condition - `ERR_PACKAGE_PATH_NOT_EXPORTED` from require.resolve
+      const esmOnlyPkgDir = join(root, "project", "node_modules", "@scope", "esm-only");
+      mkdirSync(esmOnlyPkgDir, { recursive: true });
+      writeFileSync(
+        join(esmOnlyPkgDir, "package.json"),
+        JSON.stringify({
+          name: "@scope/esm-only",
+          version: "1.0.0",
+          type: "module",
+          exports: {
+            ".": {
+              types: "./dist/index.d.mts",
+              import: "./dist/index.mjs",
+            },
+          },
+          peerDependencies: { vue: "^3.0.0" },
+        }),
+      );
+
+      // regular package - unscoped, with a plain main - installed higher up
+      // in the tree to cover the parent-dir walk.
+      const plainPkgDir = join(root, "node_modules", "plain-pkg");
+      mkdirSync(plainPkgDir, { recursive: true });
+      writeFileSync(
+        join(plainPkgDir, "package.json"),
+        JSON.stringify({ name: "plain-pkg", version: "2.0.0", main: "./index.js" }),
+      );
+    });
+
+    afterAll(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it("reads package.json of a pure-ESM package without tripping on exports", async () => {
+      const pkg = await readInstalledPackageJSON("@scope/esm-only", join(root, "project", "src"));
+      expect(pkg?.name).toBe("@scope/esm-only");
+      expect(pkg?.peerDependencies).toEqual({ vue: "^3.0.0" });
+    });
+
+    it("walks parent directories to locate a hoisted package", async () => {
+      const pkg = await readInstalledPackageJSON("plain-pkg", join(root, "project", "src"));
+      expect(pkg?.name).toBe("plain-pkg");
+      expect(pkg?.version).toBe("2.0.0");
+    });
+
+    it("returns null when the package is not installed", async () => {
+      const pkg = await readInstalledPackageJSON("does-not-exist", join(root, "project"));
+      expect(pkg).toBeNull();
+    });
+  });
+
+  describe("readPackageJSONFromResolver", () => {
+    it("resolves a package via Node's native resolver", async () => {
+      // vitest is a devDependency of this repo and has a well-formed main
+      // export reachable from `createRequire`.
+      const _require = createRequire(join(process.cwd(), "_.js"));
+      const pkg = await readPackageJSONFromResolver(_require, "vitest");
+      expect(pkg?.name).toBe("vitest");
+    });
+
+    it("returns null for an unresolvable package", async () => {
+      const _require = createRequire(join(process.cwd(), "_.js"));
+      const pkg = await readPackageJSONFromResolver(_require, "definitely-not-installed-xyz");
+      expect(pkg).toBeNull();
+    });
+  });
+
   describe("resolveOperationOptions", () => {
     it("resolved package manager by name", async () => {
       const r = await resolveOperationOptions({ packageManager: "yarn" });

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -11,47 +11,64 @@ import {
 } from "../src/_utils.ts";
 
 describe("internal utils", () => {
-  describe("readInstalledPackageJSON", () => {
-    let root!: string;
+  let root!: string;
 
-    beforeAll(() => {
-      root = mkdtempSync(join(tmpdir(), "nypm-test-"));
-      mkdirSync(join(root, "project", "src"), { recursive: true });
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "nypm-test-"));
+    mkdirSync(join(root, "project", "src"), { recursive: true });
 
-      // scoped pure-ESM package whose `exports` only defines an `import`
-      // condition - `ERR_PACKAGE_PATH_NOT_EXPORTED` from require.resolve
-      const esmOnlyPkgDir = join(root, "project", "node_modules", "@scope", "esm-only");
-      mkdirSync(esmOnlyPkgDir, { recursive: true });
-      writeFileSync(
-        join(esmOnlyPkgDir, "package.json"),
-        JSON.stringify({
-          name: "@scope/esm-only",
-          version: "1.0.0",
-          type: "module",
-          exports: {
-            ".": {
-              types: "./dist/index.d.mts",
-              import: "./dist/index.mjs",
-            },
+    // scoped pure-ESM package whose `exports` only defines an `import`
+    // condition - `ERR_PACKAGE_PATH_NOT_EXPORTED` from require.resolve
+    const esmOnlyPkgDir = join(root, "project", "node_modules", "@scope", "esm-only");
+    mkdirSync(esmOnlyPkgDir, { recursive: true });
+    writeFileSync(
+      join(esmOnlyPkgDir, "package.json"),
+      JSON.stringify({
+        name: "@scope/esm-only",
+        version: "1.0.0",
+        type: "module",
+        exports: {
+          ".": {
+            types: "./dist/index.d.mts",
+            import: "./dist/index.mjs",
           },
-          peerDependencies: { vue: "^3.0.0" },
-        }),
-      );
+        },
+        peerDependencies: { vue: "^3.0.0" },
+      }),
+    );
 
-      // regular package - unscoped, with a plain main - installed higher up
-      // in the tree to cover the parent-dir walk.
-      const plainPkgDir = join(root, "node_modules", "plain-pkg");
-      mkdirSync(plainPkgDir, { recursive: true });
-      writeFileSync(
-        join(plainPkgDir, "package.json"),
-        JSON.stringify({ name: "plain-pkg", version: "2.0.0", main: "./index.js" }),
-      );
-    });
+    // regular package - unscoped, with a plain main - installed higher up
+    // in the tree to cover the parent-dir walk.
+    const plainPkgDir = join(root, "node_modules", "plain-pkg");
+    mkdirSync(plainPkgDir, { recursive: true });
+    writeFileSync(
+      join(plainPkgDir, "package.json"),
+      JSON.stringify({ name: "plain-pkg", version: "2.0.0", main: "./index.js" }),
+    );
 
-    afterAll(() => {
-      rmSync(root, { recursive: true, force: true });
-    });
+    // package with a nested `cjs/package.json` type stub (as emitted by
+    // tshy and similar dual-build tools). `require.resolve` lands on the
+    // cjs entry, and a naive walk-up finds the stub before the real root.
+    const stubbedPkgDir = join(root, "project", "node_modules", "stubbed-pkg");
+    mkdirSync(join(stubbedPkgDir, "cjs"), { recursive: true });
+    writeFileSync(
+      join(stubbedPkgDir, "package.json"),
+      JSON.stringify({
+        name: "stubbed-pkg",
+        version: "1.0.0",
+        main: "./cjs/index.js",
+        peerDependencies: { react: "^18.0.0" },
+      }),
+    );
+    writeFileSync(join(stubbedPkgDir, "cjs", "package.json"), `{"type":"commonjs"}`);
+    writeFileSync(join(stubbedPkgDir, "cjs", "index.js"), "module.exports = {};");
+  });
 
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  describe("readInstalledPackageJSON", () => {
     it("reads package.json of a pure-ESM package without tripping on exports", async () => {
       const pkg = await readInstalledPackageJSON("@scope/esm-only", join(root, "project", "src"));
       expect(pkg?.name).toBe("@scope/esm-only");
@@ -68,6 +85,12 @@ describe("internal utils", () => {
       const pkg = await readInstalledPackageJSON("does-not-exist", join(root, "project"));
       expect(pkg).toBeNull();
     });
+
+    it("recovers the real root package.json when a nested cjs stub would shadow it", async () => {
+      const pkg = await readInstalledPackageJSON("stubbed-pkg", join(root, "project", "src"));
+      expect(pkg?.name).toBe("stubbed-pkg");
+      expect(pkg?.peerDependencies).toEqual({ react: "^18.0.0" });
+    });
   });
 
   describe("readPackageJSONFromResolver", () => {
@@ -83,6 +106,19 @@ describe("internal utils", () => {
       const _require = createRequire(join(process.cwd(), "_.js"));
       const pkg = await readPackageJSONFromResolver(_require, "definitely-not-installed-xyz");
       expect(pkg).toBeNull();
+    });
+
+    it("returns a nested package.json stub when one sits between entry and root", async () => {
+      // Documents the name-mismatch footgun: require.resolve lands on
+      // `cjs/index.js`, and the includeParentDirs walk returns the
+      // `cjs/package.json` type stub before reaching the real root.
+      // Callers must detect this (pkg.name !== pkgName) and fall back to
+      // readInstalledPackageJSON.
+      const projectDir = join(root, "project");
+      const _require = createRequire(join(projectDir, "_.js"));
+      const pkg = await readPackageJSONFromResolver(_require, "stubbed-pkg");
+      expect(pkg?.name).toBeUndefined();
+      expect(pkg?.peerDependencies).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
resolves https://github.com/nuxt/cli/issues/1226
resolves https://github.com/nuxt/hints/issues/281
resolves https://github.com/nuxt/a11y/issues/274
resolves https://github.com/e-chan1007/nuxt-monaco-editor/issues/77

similar to https://github.com/unjs/nypm/pull/230, we were receiving logs like this after installing a module:

```
■  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /private/tmp/nuxt-app/node_modules/@nuxt/ui/package.json
│
◆  Install failed for @nuxt/ui@4.6.1. Do you want to continue adding the module to nuxt.config?
```

this was because pure ESM packages were throwing on `require.resolve`...

this PR keeps approach of defaulting to `require.resolve` and then falling back to alternative approaach 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved package discovery and resolution to better handle scoped/ESM packages, parent-directory traversal, shadowed package metadata, and cases where resolver lookup fails; added safer fallback lookup and skipping of missing package entries during peer-dependency processing.

* **Tests**
  * Expanded test coverage with simulated node_modules layouts to validate resolution edge cases and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->