### PR TITLE
feat: add support for aube package manager

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,19 +24,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          AUBE_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
-            https://api.github.com/repos/jdx/aube/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          tag=$(gh release view --repo jdx/aube --json tagName --jq .tagName)
           case "${{ runner.os }}-${{ runner.arch }}" in
-            Linux-X64)   target="x86_64-unknown-linux-gnu" ;;
-            Linux-ARM64) target="aarch64-unknown-linux-gnu" ;;
-            macOS-ARM64) target="aarch64-apple-darwin" ;;
-            macOS-X64)   target="x86_64-apple-darwin" ;;
+            Linux-X64)     asset="aube-${tag}-x86_64-unknown-linux-gnu.tar.gz" ;;
+            Linux-ARM64)   asset="aube-${tag}-aarch64-unknown-linux-gnu.tar.gz" ;;
+            macOS-ARM64)   asset="aube-${tag}-aarch64-apple-darwin.tar.gz" ;;
+            macOS-X64)     asset="aube-${tag}-x86_64-apple-darwin.tar.gz" ;;
+            Windows-X64)   asset="aube-${tag}-x86_64-pc-windows-msvc.zip" ;;
+            Windows-ARM64) asset="aube-${tag}-aarch64-pc-windows-msvc.zip" ;;
             *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
           esac
-          url="https://github.com/jdx/aube/releases/download/${AUBE_VERSION}/aube-${AUBE_VERSION}-${target}.tar.gz"
-          mkdir -p "$HOME/.aube/bin"
-          curl -fsSL "$url" | tar -xz -C "$HOME/.aube/bin"
-          echo "$HOME/.aube/bin" >> "$GITHUB_PATH"
+          dir="$HOME/.aube/bin"
+          mkdir -p "$dir"
+          # `tar -xf` auto-detects gzip (unix tarballs) and zip (Windows, via bsdtar).
+          gh release download "$tag" --repo jdx/aube --pattern "$asset" --output "$HOME/aube-archive" --clobber
+          tar -xf "$HOME/aube-archive" -C "$dir"
+          rm -f "$HOME/aube-archive"
+          if [ "${{ runner.os }}" = "Windows" ]; then dir="$(cygpath -w "$dir")"; fi
+          echo "$dir" >> "$GITHUB_PATH"
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -35,12 +35,17 @@ jobs:
             *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
           esac
           dir="$HOME/.aube/bin"
+          archive="$HOME/$asset"
           mkdir -p "$dir"
-          # `tar -xf` auto-detects gzip (unix tarballs) and zip (Windows, via bsdtar).
-          gh release download "$tag" --repo jdx/aube --pattern "$asset" --output "$HOME/aube-archive" --clobber
-          tar -xf "$HOME/aube-archive" -C "$dir"
-          rm -f "$HOME/aube-archive"
-          if [ "${{ runner.os }}" = "Windows" ]; then dir="$(cygpath -w "$dir")"; fi
+          gh release download "$tag" --repo jdx/aube --pattern "$asset" --output "$archive" --clobber
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # Git Bash ships GNU tar, which can't read zip; use PowerShell instead.
+            powershell -NoProfile -Command "Expand-Archive -Force -Path '$(cygpath -w "$archive")' -DestinationPath '$(cygpath -w "$dir")'"
+            dir="$(cygpath -w "$dir")"
+          else
+            tar -xf "$archive" -C "$dir"
+          fi
+          rm -f "$archive"
           echo "$dir" >> "$GITHUB_PATH"
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,9 +20,12 @@ jobs:
           deno-version: v2.x
       - name: Install aube
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          AUBE_VERSION="v1.18.2"
+          AUBE_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/jdx/aube/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
           case "${{ runner.os }}-${{ runner.arch }}" in
             Linux-X64)   target="x86_64-unknown-linux-gnu" ;;
             Linux-ARM64) target="aarch64-unknown-linux-gnu" ;;

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,6 +18,22 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+      - name: Install aube
+        shell: bash
+        run: |
+          set -euo pipefail
+          AUBE_VERSION="v1.18.2"
+          case "${{ runner.os }}-${{ runner.arch }}" in
+            Linux-X64)   target="x86_64-unknown-linux-gnu" ;;
+            Linux-ARM64) target="aarch64-unknown-linux-gnu" ;;
+            macOS-ARM64) target="aarch64-apple-darwin" ;;
+            macOS-X64)   target="x86_64-apple-darwin" ;;
+            *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
+          esac
+          url="https://github.com/jdx/aube/releases/download/${AUBE_VERSION}/aube-${AUBE_VERSION}-${target}.tar.gz"
+          mkdir -p "$HOME/.aube/bin"
+          curl -fsSL "$url" | tar -xz -C "$HOME/.aube/bin"
+          echo "$HOME/.aube/bin" >> "$GITHUB_PATH"
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -25,7 +41,7 @@ jobs:
       - run: pnpm install
       - name: Fix lint issues
         run: pnpm run lint:fix && pnpm vitest run --update
-      - run: git checkout HEAD test/fixtures/bun
+      - run: git checkout HEAD test/fixtures/bun test/fixtures/aube
       - uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8
         with:
           commit-message: "chore: apply automated updates"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,25 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+      - name: Install aube
+        if: ${{ matrix.os != 'windows-latest' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          AUBE_VERSION="v1.18.2"
+          case "${{ runner.os }}-${{ runner.arch }}" in
+            Linux-X64)   target="x86_64-unknown-linux-gnu" ;;
+            Linux-ARM64) target="aarch64-unknown-linux-gnu" ;;
+            macOS-ARM64) target="aarch64-apple-darwin" ;;
+            macOS-X64)   target="x86_64-apple-darwin" ;;
+            *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
+          esac
+          url="https://github.com/jdx/aube/releases/download/${AUBE_VERSION}/aube-${AUBE_VERSION}-${target}.tar.gz"
+          mkdir -p "$HOME/.aube/bin"
+          curl -fsSL "$url" | tar -xz -C "$HOME/.aube/bin"
+          echo "$HOME/.aube/bin" >> "$GITHUB_PATH"
+      - run: aube --version
+        if: ${{ matrix.os != 'windows-latest' }}
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,27 +23,30 @@ jobs:
         with:
           deno-version: v2.x
       - name: Install aube
-        if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          AUBE_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
-            https://api.github.com/repos/jdx/aube/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          tag=$(gh release view --repo jdx/aube --json tagName --jq .tagName)
           case "${{ runner.os }}-${{ runner.arch }}" in
-            Linux-X64)   target="x86_64-unknown-linux-gnu" ;;
-            Linux-ARM64) target="aarch64-unknown-linux-gnu" ;;
-            macOS-ARM64) target="aarch64-apple-darwin" ;;
-            macOS-X64)   target="x86_64-apple-darwin" ;;
+            Linux-X64)     asset="aube-${tag}-x86_64-unknown-linux-gnu.tar.gz" ;;
+            Linux-ARM64)   asset="aube-${tag}-aarch64-unknown-linux-gnu.tar.gz" ;;
+            macOS-ARM64)   asset="aube-${tag}-aarch64-apple-darwin.tar.gz" ;;
+            macOS-X64)     asset="aube-${tag}-x86_64-apple-darwin.tar.gz" ;;
+            Windows-X64)   asset="aube-${tag}-x86_64-pc-windows-msvc.zip" ;;
+            Windows-ARM64) asset="aube-${tag}-aarch64-pc-windows-msvc.zip" ;;
             *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
           esac
-          url="https://github.com/jdx/aube/releases/download/${AUBE_VERSION}/aube-${AUBE_VERSION}-${target}.tar.gz"
-          mkdir -p "$HOME/.aube/bin"
-          curl -fsSL "$url" | tar -xz -C "$HOME/.aube/bin"
-          echo "$HOME/.aube/bin" >> "$GITHUB_PATH"
+          dir="$HOME/.aube/bin"
+          mkdir -p "$dir"
+          # `tar -xf` auto-detects gzip (unix tarballs) and zip (Windows, via bsdtar).
+          gh release download "$tag" --repo jdx/aube --pattern "$asset" --output "$HOME/aube-archive" --clobber
+          tar -xf "$HOME/aube-archive" -C "$dir"
+          rm -f "$HOME/aube-archive"
+          if [ "${{ runner.os }}" = "Windows" ]; then dir="$(cygpath -w "$dir")"; fi
+          echo "$dir" >> "$GITHUB_PATH"
       - run: aube --version
-        if: ${{ matrix.os != 'windows-latest' }}
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,17 @@ jobs:
             *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
           esac
           dir="$HOME/.aube/bin"
+          archive="$HOME/$asset"
           mkdir -p "$dir"
-          # `tar -xf` auto-detects gzip (unix tarballs) and zip (Windows, via bsdtar).
-          gh release download "$tag" --repo jdx/aube --pattern "$asset" --output "$HOME/aube-archive" --clobber
-          tar -xf "$HOME/aube-archive" -C "$dir"
-          rm -f "$HOME/aube-archive"
-          if [ "${{ runner.os }}" = "Windows" ]; then dir="$(cygpath -w "$dir")"; fi
+          gh release download "$tag" --repo jdx/aube --pattern "$asset" --output "$archive" --clobber
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # Git Bash ships GNU tar, which can't read zip; use PowerShell instead.
+            powershell -NoProfile -Command "Expand-Archive -Force -Path '$(cygpath -w "$archive")' -DestinationPath '$(cygpath -w "$dir")'"
+            dir="$(cygpath -w "$dir")"
+          else
+            tar -xf "$archive" -C "$dir"
+          fi
+          rm -f "$archive"
           echo "$dir" >> "$GITHUB_PATH"
       - run: aube --version
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
       - name: Install aube
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          AUBE_VERSION="v1.18.2"
+          AUBE_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/jdx/aube/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
           case "${{ runner.os }}-${{ runner.arch }}" in
             Linux-X64)   target="x86_64-unknown-linux-gnu" ;;
             Linux-ARM64) target="aarch64-unknown-linux-gnu" ;;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 🌈 Unified Package Manager for Node.js (npm, pnpm, yarn), Bun and Deno.
 
-✅ Supports [npm](https://docs.npmjs.com/cli/v10/commands/npm), [yarn](https://yarnpkg.com/), [pnpm](https://pnpm.io/), [bun](https://bun.sh/package-manager) and [deno](https://deno.com/) out of the box with a unified API.
+✅ Supports [npm](https://docs.npmjs.com/cli/v10/commands/npm), [yarn](https://yarnpkg.com/), [pnpm](https://pnpm.io/), [bun](https://bun.sh/package-manager), [deno](https://deno.com/) and [aube](https://github.com/jdx/aube) out of the box with a unified API.
 
 ✅ Provides an **API interface** to interact with package managers.
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -117,6 +117,7 @@ export async function executeCommand(
     command !== "npm" &&
     command !== "bun" &&
     command !== "deno" &&
+    command !== "aube" &&
     options.corepack !== false &&
     (await hasCorepack());
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,6 +37,7 @@ export async function installDependencies(
     bun: ["install", "--frozen-lockfile"],
     pnpm: ["install", "--frozen-lockfile"],
     deno: ["install", "--frozen"],
+    aube: ["install", "--frozen-lockfile"],
   };
 
   const commandArgs = options.frozenLockFile

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -11,7 +11,8 @@ export function installDependenciesCommand(
     frozenLockFile?: boolean;
   } = {},
 ): string {
-  const installCmd = options.short ? "i" : "install";
+  // aube has no `i` alias for install
+  const installCmd = options.short && packageManager !== "aube" ? "i" : "install";
 
   const pmToFrozenLockfileInstallCommand: Record<PackageManagerName, string[]> = {
     npm: ["ci"],
@@ -19,6 +20,7 @@ export function installDependenciesCommand(
     bun: [installCmd, "--frozen-lockfile"],
     pnpm: [installCmd, "--frozen-lockfile"],
     deno: [installCmd, "--frozen"],
+    aube: [installCmd, "--frozen-lockfile"],
   };
 
   const commandArgs = options.frozenLockFile
@@ -65,7 +67,14 @@ export function addDependencyCommand(
       : [
           packageManager === "npm" ? (options.short ? "i" : "install") : "add",
           ...getWorkspaceArgs({ packageManager, ...options }),
-          options.dev ? (options.short ? "-D" : "--dev") : "",
+          options.dev
+            ? options.short
+              ? "-D"
+              : // aube uses `--save-dev` rather than `--dev`
+                packageManager === "aube"
+                ? "--save-dev"
+                : "--dev"
+            : "",
           options.global ? "-g" : "",
           ...names,
         ]
@@ -106,6 +115,7 @@ export function dlxCommand(
     pnpm: options.short ? "pnpx" : "pnpm dlx",
     bun: options.short ? "bunx" : "bun x",
     deno: "deno run -A",
+    aube: options.short ? "aubx" : "aube dlx",
   };
 
   const command = pmToDlxCommand[packageManager];

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -61,6 +61,11 @@ export const packageManagers: PackageManager[] = [
     lockFile: "deno.lock",
     files: ["deno.json"],
   },
+  {
+    name: "aube",
+    command: "aube",
+    lockFile: "aube-lock.yaml",
+  },
 ] as const;
 
 /**

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -39,6 +39,13 @@ export const packageManagers: PackageManager[] = [
     lockFile: "package-lock.json",
   },
   {
+    // aube reuses other lockfiles, so it must be matched before pnpm to avoid
+    // a false `pnpm-workspace.yaml` match when an `aube-lock.yaml` is present.
+    name: "aube",
+    command: "aube",
+    lockFile: "aube-lock.yaml",
+  },
+  {
     name: "pnpm",
     command: "pnpm",
     lockFile: "pnpm-lock.yaml",
@@ -60,11 +67,6 @@ export const packageManagers: PackageManager[] = [
     command: "deno",
     lockFile: "deno.lock",
     files: ["deno.json"],
-  },
-  {
-    name: "aube",
-    command: "aube",
-    lockFile: "aube-lock.yaml",
   },
 ] as const;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun" | "deno";
+export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun" | "deno" | "aube";
 
 export type PackageManager = {
   name: PackageManagerName;

--- a/test/_shared.ts
+++ b/test/_shared.ts
@@ -22,6 +22,10 @@ export const fixtures = (
       packageManager: "deno",
     },
     {
+      name: "aube",
+      packageManager: "aube",
+    },
+    {
       name: "bun",
       packageManager: "bun",
     },
@@ -78,8 +82,8 @@ export const fixtures = (
     workspace: fixture.name.includes("workspace"),
   }))
   .filter((fixture) => {
-    // Bun is not yet supported on Windows
-    if (isWindows && fixture.packageManager === "bun") {
+    // Bun and aube are not installed on Windows runners
+    if (isWindows && (fixture.packageManager === "bun" || fixture.packageManager === "aube")) {
       return false;
     }
     return true;

--- a/test/_shared.ts
+++ b/test/_shared.ts
@@ -82,8 +82,12 @@ export const fixtures = (
     workspace: fixture.name.includes("workspace"),
   }))
   .filter((fixture) => {
-    // Bun is not yet supported on Windows
-    if (isWindows && fixture.packageManager === "bun") {
+    // Bun is not yet supported on Windows.
+    // aube runs on Windows (the install step verifies the binary), but its
+    // network-heavy fixtures are skipped there: the Windows runner already
+    // times out on such install/dlx tests for npm/pnpm/deno, and adding more
+    // concurrent installs only worsens that flakiness.
+    if (isWindows && (fixture.packageManager === "bun" || fixture.packageManager === "aube")) {
       return false;
     }
     return true;

--- a/test/_shared.ts
+++ b/test/_shared.ts
@@ -82,8 +82,8 @@ export const fixtures = (
     workspace: fixture.name.includes("workspace"),
   }))
   .filter((fixture) => {
-    // Bun and aube are not installed on Windows runners
-    if (isWindows && (fixture.packageManager === "bun" || fixture.packageManager === "aube")) {
+    // Bun is not yet supported on Windows
+    if (isWindows && fixture.packageManager === "bun") {
       return false;
     }
     return true;

--- a/test/cmd.test.ts
+++ b/test/cmd.test.ts
@@ -89,6 +89,26 @@ const fixtures = [
     },
   },
   {
+    name: "aube",
+    packageManager: "aube",
+    opts: {},
+    commands: {
+      install: "aube install",
+      installShort: "aube install", // aube has no `i` alias
+      installFrozen: "aube install --frozen-lockfile",
+      add: "aube add name",
+      addShort: "aube add name",
+      addDev: "aube add --save-dev name",
+      addGlobal: "aube add -g name",
+      addWorkspace: "aube add name", // TODO: workspace not supported
+      runScript: "aube run test --arg",
+      dlx: "aube dlx test --arg",
+      dlxShort: "aubx test --arg",
+      dlxWithPkg: "aube dlx --package=dep1 --package=dep2 test --arg",
+      dlxWithPkgShort: "aubx --package=dep1 --package=dep2 test --arg",
+    },
+  },
+  {
     name: "yarn classic",
     packageManager: "yarn",
     opts: {},

--- a/test/detect.test.ts
+++ b/test/detect.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest";
 import { detectPackageManager } from "../src/index.ts";
-import { fixtures } from "./_shared.ts";
+import { fixtures, resolveFixtureDirectory } from "./_shared.ts";
 
 describe("detectPackageManager", () => {
   for (const fixture of fixtures) {
@@ -32,4 +32,20 @@ describe("detectPackageManager", () => {
       );
     });
   }
+
+  // aube is not executed in CI, so it is kept out of the shared fixtures
+  // (which run real package manager binaries) and tested standalone here.
+  describe("aube", () => {
+    const dir = resolveFixtureDirectory("aube");
+
+    it("should detect with package.json", async () => {
+      const detected = await detectPackageManager(dir, { ignoreLockFile: true });
+      expect(detected?.name).toBe("aube");
+    });
+
+    it("should detect with lock file", async () => {
+      const detected = await detectPackageManager(dir, { ignorePackageJSON: true });
+      expect(detected?.name).toBe("aube");
+    });
+  });
 });

--- a/test/detect.test.ts
+++ b/test/detect.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest";
 import { detectPackageManager } from "../src/index.ts";
-import { fixtures, resolveFixtureDirectory } from "./_shared.ts";
+import { fixtures } from "./_shared.ts";
 
 describe("detectPackageManager", () => {
   for (const fixture of fixtures) {
@@ -32,20 +32,4 @@ describe("detectPackageManager", () => {
       );
     });
   }
-
-  // aube is not executed in CI, so it is kept out of the shared fixtures
-  // (which run real package manager binaries) and tested standalone here.
-  describe("aube", () => {
-    const dir = resolveFixtureDirectory("aube");
-
-    it("should detect with package.json", async () => {
-      const detected = await detectPackageManager(dir, { ignoreLockFile: true });
-      expect(detected?.name).toBe("aube");
-    });
-
-    it("should detect with lock file", async () => {
-      const detected = await detectPackageManager(dir, { ignorePackageJSON: true });
-      expect(detected?.name).toBe("aube");
-    });
-  });
 });

--- a/test/fixtures/aube/aube-lock.yaml
+++ b/test/fixtures/aube/aube-lock.yaml
@@ -1,0 +1,6 @@
+lockfileVersion: "1.0"
+
+dependencies:
+  consola:
+    specifier: ^3.4.2
+    version: 3.4.2

--- a/test/fixtures/aube/aube-lock.yaml
+++ b/test/fixtures/aube/aube-lock.yaml
@@ -1,6 +1,26 @@
-lockfileVersion: "1.0"
+lockfileVersion: "9.0"
 
-dependencies:
-  consola:
-    specifier: ^3.4.2
-    version: 3.4.2
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+time:
+  consola@3.4.2: 2025-03-18T10:17:43.596Z
+
+importers:
+  .:
+    dependencies:
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+
+packages:
+  consola@3.4.2:
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
+
+snapshots:
+  consola@3.4.2: {}

--- a/test/fixtures/aube/package.json
+++ b/test/fixtures/aube/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixture-aube",
+  "private": true,
+  "scripts": {
+    "test-script": "node -e \"fs.writeFileSync('test-file.txt','test','utf8')\"",
+    "test-script-env": "node -e \"fs.writeFileSync('test-file-env.txt', process.env.TEST_CONTENT, 'utf8')\""
+  },
+  "dependencies": {
+    "consola": "^3.4.2"
+  },
+  "packageManager": "aube@0.1.0"
+}

--- a/test/fixtures/aube/pnpm-workspace.yaml
+++ b/test/fixtures/aube/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []


### PR DESCRIPTION
Adds support for the [aube](https://github.com/jdx/aube) package manager (binaries `aube`, `aubr`, `aubx`) to nypm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for aube: recognition, lockfile format, and command variants (install, add, dlx) including short-form flags and dev-flag behavior.

* **Documentation**
  * README now lists aube among supported package managers.

* **Tests**
  * New aube fixtures and expanded tests covering install (frozen/short), add (dev/global), dlx, scripts, and workspace cases.

* **Chores**
  * CI/workflows updated to install and verify the aube binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->