### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.6.7",
   "description": "Unified Package Manager for Node.js",
   "license": "MIT",
+  "homepage": "https://github.com/unjs/nypm",
   "repository": "unjs/nypm",
+  "bugs": {
+    "url": "https://github.com/unjs/nypm/issues"
+  },
   "bin": {
     "nypm": "./dist/cli.mjs"
   },


### PR DESCRIPTION
## Summary
- add the missing npm `homepage` metadata
- add `bugs.url` pointing to the public issue tracker

## Validation
- `npm pkg get name version homepage repository bugs --silent`
- `npm pack --dry-run --ignore-scripts --json --silent`
- `git diff --check`

This is a package metadata-only change; runtime code, dependencies, exports, and build behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with a homepage field and bugs tracking information for improved project discoverability and issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->