### PR TITLE
feat: add nub package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 🌈 Unified Package Manager for Node.js (npm, pnpm, yarn), Bun and Deno.
 
-✅ Supports [npm](https://docs.npmjs.com/cli/v10/commands/npm), [yarn](https://yarnpkg.com/), [pnpm](https://pnpm.io/), [bun](https://bun.sh/package-manager), [deno](https://deno.com/) and [aube](https://github.com/jdx/aube) out of the box with a unified API.
+✅ Supports [npm](https://docs.npmjs.com/cli/v10/commands/npm), [yarn](https://yarnpkg.com/), [pnpm](https://pnpm.io/), [bun](https://bun.sh/package-manager), [deno](https://deno.com/), [aube](https://github.com/jdx/aube) and [nub](https://github.com/nubjs/nub) out of the box with a unified API.
 
 ✅ Provides an **API interface** to interact with package managers.
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -118,6 +118,7 @@ export async function executeCommand(
     command !== "bun" &&
     command !== "deno" &&
     command !== "aube" &&
+    command !== "nub" &&
     options.corepack !== false &&
     (await hasCorepack());
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,6 +38,7 @@ export async function installDependencies(
     pnpm: ["install", "--frozen-lockfile"],
     deno: ["install", "--frozen"],
     aube: ["install", "--frozen-lockfile"],
+    nub: ["install", "--frozen-lockfile"],
   };
 
   const commandArgs = options.frozenLockFile

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -71,8 +71,8 @@ export function addDependencyCommand(
           options.dev
             ? options.short
               ? "-D"
-              : // aube uses `--save-dev` rather than `--dev`
-                packageManager === "aube"
+              : // aube and nub use `--save-dev` rather than `--dev`
+                packageManager === "aube" || packageManager === "nub"
                 ? "--save-dev"
                 : "--dev"
             : "",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -21,6 +21,7 @@ export function installDependenciesCommand(
     pnpm: [installCmd, "--frozen-lockfile"],
     deno: [installCmd, "--frozen"],
     aube: [installCmd, "--frozen-lockfile"],
+    nub: [installCmd, "--frozen-lockfile"],
   };
 
   const commandArgs = options.frozenLockFile
@@ -116,6 +117,7 @@ export function dlxCommand(
     bun: options.short ? "bunx" : "bun x",
     deno: "deno run -A",
     aube: options.short ? "aubx" : "aube dlx",
+    nub: options.short ? "nubx" : "nub dlx",
   };
 
   const command = pmToDlxCommand[packageManager];

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -46,6 +46,13 @@ export const packageManagers: PackageManager[] = [
     lockFile: "aube-lock.yaml",
   },
   {
+    // nub is lockfile-compatible (it round-trips npm/pnpm/bun lockfiles) and
+    // has no lockfile of its own, so it is detected via the `packageManager`
+    // field or the `nub` command, never an implicit lockfile match.
+    name: "nub",
+    command: "nub",
+  },
+  {
     name: "pnpm",
     command: "pnpm",
     lockFile: "pnpm-lock.yaml",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun" | "deno" | "aube";
+export type PackageManagerName = "npm" | "yarn" | "pnpm" | "bun" | "deno" | "aube" | "nub";
 
 export type PackageManager = {
   name: PackageManagerName;

--- a/test/_shared.ts
+++ b/test/_shared.ts
@@ -27,6 +27,10 @@ export const fixtures = (
       packageManager: "aube",
     },
     {
+      name: "nub",
+      packageManager: "nub",
+    },
+    {
       name: "bun",
       packageManager: "bun",
     },
@@ -105,7 +109,9 @@ const availabilityCache = new Map<PackageManagerName, boolean>();
  *
  * Used to skip fixtures that drive the real CLI (install/add/dlx/...) when the
  * binary is missing locally. `aube` is not provided by corepack and is only
- * installed in CI, so its tests are ignored on machines without it.
+ * installed in CI, so its tests are ignored on machines without it. `nub` is
+ * likewise not a corepack PM; its real-CLI tests run only where `nub` is
+ * installed, while its detection tests need no binary.
  */
 export function isPackageManagerAvailable(packageManager: PackageManagerName): boolean {
   if (!availabilityCache.has(packageManager)) {

--- a/test/cmd.test.ts
+++ b/test/cmd.test.ts
@@ -109,6 +109,26 @@ const fixtures = [
     },
   },
   {
+    name: "nub",
+    packageManager: "nub",
+    opts: {},
+    commands: {
+      install: "nub install",
+      installShort: "nub i",
+      installFrozen: "nub install --frozen-lockfile",
+      add: "nub add name",
+      addShort: "nub add name",
+      addDev: "nub add --dev name",
+      addGlobal: "nub add -g name",
+      addWorkspace: "nub add name", // TODO: workspace not supported
+      runScript: "nub run test --arg",
+      dlx: "nub dlx test --arg",
+      dlxShort: "nubx test --arg",
+      dlxWithPkg: "nub dlx --package=dep1 --package=dep2 test --arg",
+      dlxWithPkgShort: "nubx --package=dep1 --package=dep2 test --arg",
+    },
+  },
+  {
     name: "yarn classic",
     packageManager: "yarn",
     opts: {},

--- a/test/cmd.test.ts
+++ b/test/cmd.test.ts
@@ -118,7 +118,7 @@ const fixtures = [
       installFrozen: "nub install --frozen-lockfile",
       add: "nub add name",
       addShort: "nub add name",
-      addDev: "nub add --dev name",
+      addDev: "nub add --save-dev name",
       addGlobal: "nub add -g name",
       addWorkspace: "nub add name", // TODO: workspace not supported
       runScript: "nub run test --arg",

--- a/test/detect.test.ts
+++ b/test/detect.test.ts
@@ -18,7 +18,9 @@ describe("detectPackageManager", () => {
         }
       });
 
-      it.skipIf(fixture.name.includes("berry") /* TODO */)(
+      // nub is lockfile-compatible and has no lockfile of its own, so it is
+      // only detectable via the `packageManager` field, not an implicit file.
+      it.skipIf(fixture.name.includes("berry") /* TODO */ || fixture.packageManager === "nub")(
         "should detect with lock file",
         async () => {
           const detected = await detectPackageManager(fixture.dir, {

--- a/test/fixtures/nub/package.json
+++ b/test/fixtures/nub/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixture-nub",
+  "private": true,
+  "scripts": {
+    "test-script": "node -e \"fs.writeFileSync('test-file.txt','test','utf8')\"",
+    "test-script-env": "node -e \"fs.writeFileSync('test-file-env.txt', process.env.TEST_CONTENT, 'utf8')\""
+  },
+  "dependencies": {
+    "consola": "^3.4.2"
+  },
+  "packageManager": "nub@0.1.0"
+}


### PR DESCRIPTION
Adds [nub](https://github.com/nubjs/nub), a pnpm-compatible-CLI package manager that vendors [aube](https://github.com/jdx/aube) as its engine. Mirrors the `aube` entry, minus the lockfile: nub is lockfile-compatible with no lockfile of its own, so detection uses the `packageManager` field, not a signature lockfile.

Every produced command is empirically verified against the real `nub` binary: install/`i`, `--frozen-lockfile`, add (`--save-dev`/`-D`/`-g`), remove (`-D`/`-g`), dedupe, run, dlx via `nubx`/`nub dlx`. corepack-excluded. types/lint/cmd/detect + 13 real-CLI api/dedupe tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the **nub** package manager across detection, command generation, and dependency installation.
  * Added a new test fixture covering nub-specific script and command behavior.

* **Bug Fixes**
  * Improved dev-dependency handling so nub uses the correct install flag.
  * Updated command execution behavior so nub is run directly when appropriate.

* **Documentation**
  * Updated the README to include nub in the supported package manager list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->