### PR TITLE
fix: ignore stdin for package manager commands

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -130,7 +130,11 @@ export async function executeCommand(
     nodeOptions: {
       cwd: resolve(options.cwd || process.cwd()),
       env: options.env,
-      stdio: options.silent ? "pipe" : ["ignore", "inherit", "inherit"],
+      stdio: options.silent
+        ? "pipe"
+        : process.stdin.isTTY
+          ? "inherit"
+          : ["ignore", "inherit", "inherit"],
     },
   });
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -130,7 +130,7 @@ export async function executeCommand(
     nodeOptions: {
       cwd: resolve(options.cwd || process.cwd()),
       env: options.env,
-      stdio: options.silent ? "pipe" : "inherit",
+      stdio: options.silent ? "pipe" : ["ignore", "inherit", "inherit"],
     },
   });
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,3 +1,4 @@
+import type { StdioOptions } from "node:child_process";
 import { createRequire } from "node:module";
 import { normalize, resolve } from "pathe";
 import { x } from "tinyexec";
@@ -126,15 +127,20 @@ export async function executeCommand(
     ? ["corepack", [command, ...args]]
     : [command, args];
 
+  // Only hand our stdin to the package manager when it is an interactive terminal.
+  // Otherwise the child gets `/dev/null` (immediate EOF) so that prompts nobody can
+  // answer (e.g. pnpm's `Proceed? (Y/n)`) fall back to their defaults instead of
+  // hanging forever. (#118)
+  const stdin = process.stdin.isTTY ? "inherit" : "ignore";
+  const stdio: StdioOptions = options.silent
+    ? [stdin, "pipe", "pipe"]
+    : [stdin, "inherit", "inherit"];
+
   const { exitCode, stdout, stderr } = await x(xArgs[0], xArgs[1], {
     nodeOptions: {
       cwd: resolve(options.cwd || process.cwd()),
       env: options.env,
-      stdio: options.silent
-        ? "pipe"
-        : process.stdin.isTTY
-          ? "inherit"
-          : ["ignore", "inherit", "inherit"],
+      stdio,
     },
   });
 

--- a/test/execute-command.test.ts
+++ b/test/execute-command.test.ts
@@ -6,12 +6,21 @@ vi.mock("tinyexec", () => ({ x }));
 
 const { executeCommand } = await import("../src/_utils.ts");
 
+function mockStdinTTY(isTTY: boolean) {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: isTTY,
+  });
+}
+
 describe("executeCommand", () => {
   afterEach(() => {
     x.mockReset();
+    vi.restoreAllMocks();
   });
 
-  it("does not connect package manager commands to stdin", async () => {
+  it("does not connect package manager commands to stdin without a parent TTY", async () => {
+    mockStdinTTY(false);
     x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
 
     await executeCommand("pnpm", ["install"], {
@@ -30,7 +39,26 @@ describe("executeCommand", () => {
     );
   });
 
+  it("inherits stdio when the parent process has a TTY", async () => {
+    mockStdinTTY(true);
+    x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    await executeCommand("pnpm", ["install"], {
+      cwd: "/tmp/project",
+      corepack: false,
+    });
+
+    expect(x).toHaveBeenCalledWith(
+      "pnpm",
+      ["install"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({ stdio: "inherit" }),
+      }),
+    );
+  });
+
   it("keeps piped stdio when silent", async () => {
+    mockStdinTTY(true);
     x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
 
     await executeCommand("pnpm", ["install"], {

--- a/test/execute-command.test.ts
+++ b/test/execute-command.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const x = vi.fn();
+
+vi.mock("tinyexec", () => ({ x }));
+
+const { executeCommand } = await import("../src/_utils.ts");
+
+describe("executeCommand", () => {
+  afterEach(() => {
+    x.mockReset();
+  });
+
+  it("does not connect package manager commands to stdin", async () => {
+    x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    await executeCommand("pnpm", ["install"], {
+      cwd: "/tmp/project",
+      corepack: false,
+    });
+
+    expect(x).toHaveBeenCalledWith(
+      "pnpm",
+      ["install"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({
+          stdio: ["ignore", "inherit", "inherit"],
+        }),
+      }),
+    );
+  });
+
+  it("keeps piped stdio when silent", async () => {
+    x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    await executeCommand("pnpm", ["install"], {
+      corepack: false,
+      silent: true,
+    });
+
+    expect(x).toHaveBeenCalledWith(
+      "pnpm",
+      ["install"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({ stdio: "pipe" }),
+      }),
+    );
+  });
+});

--- a/test/execute-command.test.ts
+++ b/test/execute-command.test.ts
@@ -5,6 +5,7 @@ const x = vi.fn();
 vi.mock("tinyexec", () => ({ x }));
 
 const { executeCommand } = await import("../src/_utils.ts");
+const originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
 function mockStdinTTY(isTTY: boolean) {
   Object.defineProperty(process.stdin, "isTTY", {
@@ -17,6 +18,11 @@ describe("executeCommand", () => {
   afterEach(() => {
     x.mockReset();
     vi.restoreAllMocks();
+    if (originalStdinIsTTY) {
+      Object.defineProperty(process.stdin, "isTTY", originalStdinIsTTY);
+    } else {
+      delete (process.stdin as { isTTY?: boolean }).isTTY;
+    }
   });
 
   it("does not connect package manager commands to stdin without a parent TTY", async () => {

--- a/test/execute-command.test.ts
+++ b/test/execute-command.test.ts
@@ -1,23 +1,33 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const x = vi.fn();
+const { x } = vi.hoisted(() => ({ x: vi.fn() }));
 
 vi.mock("tinyexec", () => ({ x }));
 
 const { executeCommand } = await import("../src/_utils.ts");
 const originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
-function mockStdinTTY(isTTY: boolean) {
+function mockStdinTTY(isTTY: boolean | undefined) {
   Object.defineProperty(process.stdin, "isTTY", {
     configurable: true,
+    writable: true,
     value: isTTY,
   });
+}
+
+function expectStdio(stdio: unknown) {
+  expect(x).toHaveBeenCalledWith(
+    "pnpm",
+    ["install"],
+    expect.objectContaining({
+      nodeOptions: expect.objectContaining({ stdio }),
+    }),
+  );
 }
 
 describe("executeCommand", () => {
   afterEach(() => {
     x.mockReset();
-    vi.restoreAllMocks();
     if (originalStdinIsTTY) {
       Object.defineProperty(process.stdin, "isTTY", originalStdinIsTTY);
     } else {
@@ -26,7 +36,8 @@ describe("executeCommand", () => {
   });
 
   it("does not connect package manager commands to stdin without a parent TTY", async () => {
-    mockStdinTTY(false);
+    // Node leaves `isTTY` undefined (rather than `false`) when stdin is not a terminal
+    mockStdinTTY(undefined);
     x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
 
     await executeCommand("pnpm", ["install"], {
@@ -34,15 +45,7 @@ describe("executeCommand", () => {
       corepack: false,
     });
 
-    expect(x).toHaveBeenCalledWith(
-      "pnpm",
-      ["install"],
-      expect.objectContaining({
-        nodeOptions: expect.objectContaining({
-          stdio: ["ignore", "inherit", "inherit"],
-        }),
-      }),
-    );
+    expectStdio(["ignore", "inherit", "inherit"]);
   });
 
   it("inherits stdio when the parent process has a TTY", async () => {
@@ -54,16 +57,10 @@ describe("executeCommand", () => {
       corepack: false,
     });
 
-    expect(x).toHaveBeenCalledWith(
-      "pnpm",
-      ["install"],
-      expect.objectContaining({
-        nodeOptions: expect.objectContaining({ stdio: "inherit" }),
-      }),
-    );
+    expectStdio(["inherit", "inherit", "inherit"]);
   });
 
-  it("keeps piped stdio when silent", async () => {
+  it("keeps piped output when silent", async () => {
     mockStdinTTY(true);
     x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
 
@@ -72,12 +69,27 @@ describe("executeCommand", () => {
       silent: true,
     });
 
-    expect(x).toHaveBeenCalledWith(
-      "pnpm",
-      ["install"],
-      expect.objectContaining({
-        nodeOptions: expect.objectContaining({ stdio: "pipe" }),
-      }),
-    );
+    expectStdio(["inherit", "pipe", "pipe"]);
+  });
+
+  it("does not connect silent commands to stdin without a parent TTY", async () => {
+    mockStdinTTY(undefined);
+    x.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    await executeCommand("pnpm", ["install"], {
+      corepack: false,
+      silent: true,
+    });
+
+    expectStdio(["ignore", "pipe", "pipe"]);
+  });
+
+  it("includes captured output in the error message when a silent command fails", async () => {
+    mockStdinTTY(undefined);
+    x.mockResolvedValueOnce({ exitCode: 1, stdout: "some stdout", stderr: "some stderr" });
+
+    await expect(
+      executeCommand("pnpm", ["install"], { corepack: false, silent: true }),
+    ).rejects.toThrow(/`pnpm install` failed\.\nsome stdout\nsome stderr/);
   });
 });


### PR DESCRIPTION
## Summary\n- disconnect package-manager child processes from stdin when output is inherited\n- keep silent mode using piped stdio so errors can include stdout/stderr\n- add coverage for both stdio modes\n\nCloses #118\n\n## Validation\n- pnpm exec vitest run test/execute-command.test.ts\n- pnpm test:types\n- pnpm lint\n- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution stdio handling by detecting whether input comes from an interactive terminal, ensuring interactive runs use inherited stdin while non-interactive runs ignore stdin as appropriate.
  * Refined silent-mode stdio behavior so captured output/pipes behave consistently across TTY and non-TTY environments.
* **Tests**
  * Expanded Vitest coverage for command execution, including all TTY vs non-TTY and silent vs non-silent combinations, plus verification of error output when silent commands fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->