### PR TITLE
fix: detect `nub.lock`

### DIFF
--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -46,11 +46,11 @@ export const packageManagers: PackageManager[] = [
     lockFile: "aube-lock.yaml",
   },
   {
-    // nub is lockfile-compatible (it round-trips npm/pnpm/bun lockfiles) and
-    // has no lockfile of its own, so it is detected via the `packageManager`
-    // field or the `nub` command, never an implicit lockfile match.
+    // nub's native lockfile (nub.lock) is pnpm-v9-compatible YAML, so it must
+    // be matched before pnpm to avoid a false `pnpm-workspace.yaml` match.
     name: "nub",
     command: "nub",
+    lockFile: "nub.lock",
   },
   {
     name: "pnpm",

--- a/test/detect.test.ts
+++ b/test/detect.test.ts
@@ -21,9 +21,7 @@ describe("detectPackageManager", () => {
         }
       });
 
-      // nub is lockfile-compatible and has no lockfile of its own, so it is
-      // only detectable via the `packageManager` field, not an implicit file.
-      it.skipIf(fixture.name.includes("berry") /* TODO */ || fixture.packageManager === "nub")(
+      it.skipIf(fixture.name.includes("berry") /* TODO */)(
         "should detect with lock file",
         async () => {
           const detected = await detectPackageManager(fixture.dir, {

--- a/test/fixtures/nub/nub.lock
+++ b/test/fixtures/nub/nub.lock
@@ -1,0 +1,26 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+time:
+  consola@3.4.2: 2025-03-18T10:17:43.596Z
+
+importers:
+  .:
+    dependencies:
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+
+packages:
+  consola@3.4.2:
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
+
+snapshots:
+  consola@3.4.2: {}


### PR DESCRIPTION
Sorry for the turnover here. Nub has now added its own `nub.lock` lockfile (was previously piggybacking on other lockfiles) so best practices for detection have changed. Thanks!

---

Follow-up to #247, which added the nub entry but omitted the `lockFile` field.

Adds `lockFile: "nub.lock"` to the nub package-manager entry. nub's native lockfile (`nub.lock`) is pnpm-v9-compatible YAML, so this completes lockfile-based detection for nub the same way it already works for the other managers.

Also un-skips the nub lockfile-detection assertion in `test/detect.test.ts` and adds a matching fixture at `test/fixtures/nub/nub.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved package manager detection to recognize `nub` projects through `nub.lock` automatically.
  * Added support for a native lockfile format that works alongside existing detection methods.

* **Bug Fixes**
  * Made `nub` detection more reliable, especially in setups that rely on lockfile-based identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
