### PR TITLE
fix: select the workspace root for aube and nub

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -201,8 +201,12 @@ export function getWorkspaceArgs(
       ? options.workspace
       : undefined;
 
-  // pnpm
-  if (options.packageManager.name === "pnpm") {
+  // pnpm (aube and nub expose pnpm's `--filter` / `--workspace-root` selectors)
+  if (
+    options.packageManager.name === "pnpm" ||
+    options.packageManager.name === "aube" ||
+    options.packageManager.name === "nub"
+  ) {
     return workspacePkg ? ["--filter", workspacePkg] : ["--workspace-root"];
   }
 
@@ -238,8 +242,12 @@ export function getWorkspaceArgs2(options: {
       ? options.workspace
       : undefined;
 
-  // pnpm
-  if (options.packageManager === "pnpm") {
+  // pnpm (aube and nub expose pnpm's `--filter` / `--workspace-root` selectors)
+  if (
+    options.packageManager === "pnpm" ||
+    options.packageManager === "aube" ||
+    options.packageManager === "nub"
+  ) {
     return workspacePkg ? ["--filter", workspacePkg] : ["--workspace-root"];
   }
 

--- a/test/cmd.test.ts
+++ b/test/cmd.test.ts
@@ -100,7 +100,7 @@ const fixtures = [
       addShort: "aube add name",
       addDev: "aube add --save-dev name",
       addGlobal: "aube add -g name",
-      addWorkspace: "aube add name", // TODO: workspace not supported
+      addWorkspace: "aube add --filter workspace name",
       runScript: "aube run test --arg",
       dlx: "aube dlx test --arg",
       dlxShort: "aubx test --arg",
@@ -120,7 +120,7 @@ const fixtures = [
       addShort: "nub add name",
       addDev: "nub add --save-dev name",
       addGlobal: "nub add -g name",
-      addWorkspace: "nub add name", // TODO: workspace not supported
+      addWorkspace: "nub add --filter workspace name",
       runScript: "nub run test --arg",
       dlx: "nub dlx test --arg",
       dlxShort: "nubx test --arg",
@@ -230,6 +230,14 @@ describe("commands", () => {
         ).toBe(fixture.commands.addWorkspace);
       });
     }
+  });
+
+  describe("addDependencyCommand (workspace root)", () => {
+    it.each(["pnpm", "aube", "nub"] as const)("%s", (packageManager) => {
+      expect(addDependencyCommand(packageManager, "name", { workspace: true })).toBe(
+        `${packageManager} add --workspace-root name`,
+      );
+    });
   });
 
   describe("runScriptCommand", () => {


### PR DESCRIPTION
### Problem

`getWorkspaceArgs` / `getWorkspaceArgs2` only emit a workspace selector for pnpm, npm and yarn. For `aube` and `nub`, `workspace: true` produced e.g. `nub add name` at a monorepo root — and nub (pnpm parity) refuses root installs without `-w`, so `addDependency(..., { workspace: true })` fails in nub workspaces. The `cmd.test.ts` fixtures carried a `// TODO: workspace not supported` for both.

### Fix

Both CLIs expose pnpm's selectors — `--filter <pkg>` and `-w` / `--workspace-root` ([nub docs](https://nubjs.com/docs/runner/run#-w---workspace-root); aube parses `--workspace-root` as a global flag) — so this folds them into the existing pnpm branch of both functions:

- `workspace: true` → `--workspace-root`
- `workspace: "pkg"` → `--filter pkg`

### Tests

- Updated the aube/nub `addWorkspace` fixtures from the TODO placeholder to `<pm> add --filter workspace name`
- Added a root-install case asserting `<pm> add --workspace-root name` for pnpm, aube and nub

Surfaced via haydenbleasel/ultracite#781.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace package handling for `aube` and `nub` by using compatible workspace selectors.
  * Workspace additions now target the correct workspace with the expected filtering options.
  * Added support for workspace-root dependency commands across `pnpm`, `aube`, and `nub`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->